### PR TITLE
GPI: callback refactor

### DIFF
--- a/docs/source/library_reference_c.rst
+++ b/docs/source/library_reference_c.rst
@@ -72,6 +72,10 @@ User Handles
 These types and functions are about handles the GPI provides to users
 for interacting with GPI-managed objects.
 
+.. doxygenstruct:: gpi_hdl
+.. doxygendefine:: gpi_nil_hdl
+.. doxygenfunction:: gpi_hdl_is_nil
+
 .. doxygentypedef:: gpi_sim_hdl
 .. doxygentypedef:: gpi_iterator_hdl
 .. doxygentypedef:: gpi_cb_hdl

--- a/src/cocotb/share/include/gpi.h
+++ b/src/cocotb/share/include/gpi.h
@@ -72,7 +72,13 @@ struct GpiIterator;
 /** Handle to simulation object, such as a signal. */
 typedef struct GpiObjHdl *gpi_sim_hdl;
 
-/** Handle to callback object. */
+/** Deprecated handle to callback object.
+ *
+ * \verbatim embed:rst:leading-asterisk
+ *     .. deprecated:: 2.1
+ *         See :cpp:struct:`gpi_hdl` for handles to callbacks.
+ * \endverbatim
+ */
 typedef struct GpiCbHdl *gpi_cb_hdl;
 
 /** Handle to iterator object.
@@ -80,11 +86,60 @@ typedef struct GpiCbHdl *gpi_cb_hdl;
  * Used to iterate over child handles of a smulation object.
  */
 typedef struct GpiIterator *gpi_iterator_hdl;
+
+typedef struct gpi_hdl gpi_hdl;
 #endif
+
+/** GPI handle.
+ *
+ * This type is provided to GPI users to identify an object
+ * that is managed by the GPI.
+ *
+ * Users should provide this handle to GPI functions where appropriate.
+ *
+ * \verbatim embed:rst:leading-asterisk
+ *     .. note::
+ *         These handles are simple structs and can be copied around
+ *         by user code without problems.
+ * \endverbatim
+ *
+ */
+struct gpi_hdl {
+    int32_t index;
+    uint32_t meta;
+};
+
+/** Nil handle definition.
+ *
+ * Where a @ref gpi_hdl is returned from a GPI function,
+ * if there was a problem, a nil handle is returned.
+ *
+ * This is equivalent to a `NULL` pointer,
+ * but can be safely passed to GPI functions,
+ * which will detect a nil handle.
+ *
+ * This is intended to be used when initializing a gpi_hdl.
+ */
+// clang-format off
+#ifdef __cplusplus
+#define gpi_nil_hdl {}
+#else
+#define gpi_nil_hdl {0}
+#endif
+// clang-format on
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/** Check whether the provided @ref gpi_hdl is a nil handle.
+ *
+ * @param hdl   Handle to check.
+ * @return      `1` if nil, `0` if non-nil.
+ */
+static inline int gpi_hdl_is_nil(gpi_hdl hdl) {
+    return (hdl.index == 0 && hdl.meta == 0);
+}
 
 /** @defgroup SimIntf Simulator Control and Interrogation
  * These functions are for controlling and querying
@@ -408,9 +463,9 @@ typedef enum gpi_edge_e {
  * @param time          Time delay in simulation time units.
  * @return              Handle to callback object.
  */
-GPI_EXPORT gpi_cb_hdl gpi_register_timed_callback(int (*gpi_function)(void *),
-                                                  void *gpi_cb_data,
-                                                  uint64_t time);
+GPI_EXPORT gpi_hdl gpi_register_timed_callback(int (*gpi_function)(void *),
+                                               void *gpi_cb_data,
+                                               uint64_t time);
 
 /** Register a value change callback.
  *
@@ -420,7 +475,7 @@ GPI_EXPORT gpi_cb_hdl gpi_register_timed_callback(int (*gpi_function)(void *),
  * @param edge          Type of value change to monitor for.
  * @return              Handle to callback object.
  */
-GPI_EXPORT gpi_cb_hdl gpi_register_value_change_callback(
+GPI_EXPORT gpi_hdl gpi_register_value_change_callback(
     int (*gpi_function)(void *), void *gpi_cb_data, gpi_sim_hdl sig_hdl,
     gpi_edge edge);
 
@@ -431,8 +486,8 @@ GPI_EXPORT gpi_cb_hdl gpi_register_value_change_callback(
  * @param gpi_cb_data   Pointer to user data to be passed to callback function.
  * @return              Handle to callback object.
  */
-GPI_EXPORT gpi_cb_hdl
-gpi_register_readonly_callback(int (*gpi_function)(void *), void *gpi_cb_data);
+GPI_EXPORT gpi_hdl gpi_register_readonly_callback(int (*gpi_function)(void *),
+                                                  void *gpi_cb_data);
 
 /** Register a next timestep simulation phase callback.
  *
@@ -441,8 +496,8 @@ gpi_register_readonly_callback(int (*gpi_function)(void *), void *gpi_cb_data);
  * @param gpi_cb_data   Pointer to user data to be passed to callback function.
  * @return              Handle to callback object.
  */
-GPI_EXPORT gpi_cb_hdl
-gpi_register_nexttime_callback(int (*gpi_function)(void *), void *gpi_cb_data);
+GPI_EXPORT gpi_hdl gpi_register_nexttime_callback(int (*gpi_function)(void *),
+                                                  void *gpi_cb_data);
 
 /** Register a readwrite simulation phase callback.
  *
@@ -451,8 +506,8 @@ gpi_register_nexttime_callback(int (*gpi_function)(void *), void *gpi_cb_data);
  * @param gpi_cb_data   Pointer to user data to be passed to callback function.
  * @return              Handle to callback object.
  */
-GPI_EXPORT gpi_cb_hdl
-gpi_register_readwrite_callback(int (*gpi_function)(void *), void *gpi_cb_data);
+GPI_EXPORT gpi_hdl gpi_register_readwrite_callback(int (*gpi_function)(void *),
+                                                   void *gpi_cb_data);
 
 /** Register a callback to run at the start of simulation time.
  *
@@ -495,18 +550,19 @@ GPI_EXPORT int gpi_register_finalize_callback(gpi_finalize_callback cb,
  * @param cb_hdl    The handle to the callback to remove.
  * @return          `0` on successful removal, `1` otherwise.
  */
-GPI_EXPORT int gpi_remove_cb(gpi_cb_hdl cb_hdl);
+GPI_EXPORT int gpi_remove_cb(gpi_hdl cb_hdl);
 
 /** Retrieve user callback information from callback handle.
- *
- * This function cannot fail.
  *
  * @param cb_hdl    The handle to the callback.
  * @param cb_func   Where the user callback function should be placed.
  * @param cb_data   Where the user callback function data should be placed.
+ * @return          `0` if handle is valid, `1` if not valid.
+ *                  If any pointer passed in is `NULL`, but handle is valid,
+ *                  `0` is still returned.
  */
-GPI_EXPORT void gpi_get_cb_info(gpi_cb_hdl cb_hdl, int (**cb_func)(void *),
-                                void **cb_data);
+GPI_EXPORT int gpi_get_cb_info(gpi_hdl cb_hdl, int (**cb_func)(void *),
+                               void **cb_data);
 
 /** @} */  // End of group SimCallbacks
 

--- a/src/cocotb/share/lib/gpi/GpiCbHdl.cpp
+++ b/src/cocotb/share/lib/gpi/GpiCbHdl.cpp
@@ -5,7 +5,16 @@
 
 #include <gpi.h>
 
+#include <cstddef>
+#include <vector>
+
 #include "./gpi_priv.hpp"
+#include "./logging.hpp"
+
+// We store pointers to value change callbacks that have been
+// removed during user callbacks, then clean everything up
+// before returning to the simulator.
+static std::vector<gpi_callback *> removed_valuechange_cbs;
 
 const char *GpiObjHdl::get_name_str() { return m_name.c_str(); }
 
@@ -54,4 +63,337 @@ int GpiObjHdl::initialise(const std::string &name, const std::string &fq_name) {
     m_name = name;
     m_fullname = fq_name;
     return 0;
+}
+
+// Xar (Exponential Array) support
+// Made of separately allocated arrays (chunks) to keep pointer stability
+// Each chunk of the array doubles the total size of the array
+// [4kB][4kB][8kB][16kB]...
+// Details about Xar can be seen in Andrew Reece's BSC 2025 talk
+// Assuming as Much as Possible at https://youtu.be/i-h95QIGchY?t=3191
+
+// Define helper function/macro in terms of compiler intrinsics
+#if defined(_MSC_VER) || (defined(_WIN32) && defined(__clang__))
+
+static inline uint8_t MSB32(uint32_t x) {
+    unsigned long result = 0;
+    _BitScanReverse(&result, x);
+    return (uint8_t)result;
+}
+
+#elif defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
+
+#define MSB32(x) ((uint8_t)(31 - __builtin_clz(x)))
+
+#else
+#error "clz intrinsics not defined for this compiler."
+#endif
+
+// Shift defines how many callbacks in the first chunk (1 << CB_SHIFT)
+#define CB_SHIFT 12  // First chunk is 4096
+#define CB_CHUNK_COUNT 16
+static gpi_callback *callback_chunks[CB_CHUNK_COUNT] = {};
+// With these parameters, the Xar can hold ~134 million callbacks if it were
+// fully allocated
+
+static gpi_callback *free_callback = nullptr;
+static int32_t callback_count = 0;
+
+struct xar_elem_info {
+    int32_t chunk_index;
+    uint32_t chunk_capacity;
+    uint32_t elem_index;
+};
+
+static inline xar_elem_info xar_get_elem_info(uint32_t shift, int32_t index) {
+    // Initialize data for lookup in xar
+    uint32_t elem_index = static_cast<uint32_t>(index);
+    uint32_t chunk_capacity = 1 << shift;
+    uint8_t chunk_index = 0;
+
+    // Check if index is outside first chunk
+    uint32_t i_shift = elem_index >> shift;
+    if (i_shift > 0) {
+        // Calculate target chunk and the index within it
+        chunk_index = MSB32(i_shift);
+        chunk_capacity = 1 << (chunk_index + shift);
+        elem_index -= chunk_capacity;
+        chunk_index++;
+    }
+
+    // Return calculated info for element at index
+    return xar_elem_info{chunk_index, chunk_capacity, elem_index};
+}
+
+gpi_callback *gpi_callback_acquire() {
+    gpi_callback *cb = free_callback;
+
+    if (cb) {
+        free_callback = free_callback->next;
+    } else {
+        // Get info about where in xar the next callback object is
+        xar_elem_info cb_info = xar_get_elem_info(CB_SHIFT, callback_count);
+
+        // If the callback is in a chunk that hasn't been allocated yet, do the
+        // allocation.
+        // Use calloc to get zero-initialized callback objects.
+        if (!callback_chunks[cb_info.chunk_index]) {
+            callback_chunks[cb_info.chunk_index] = static_cast<gpi_callback *>(
+                calloc(cb_info.chunk_capacity, sizeof(gpi_callback)));
+            LOG_TRACE(
+                "GPI: allocating callback pool chunk index %d of capacity %d",
+                cb_info.chunk_index, cb_info.chunk_capacity);
+        }
+
+        cb = &callback_chunks[cb_info.chunk_index][cb_info.elem_index];
+        cb->index = callback_count;
+        callback_count += 1;
+    }
+
+    // Preserve persistent data and clear the rest
+    meta32 meta = cb->meta;
+    int32_t index = cb->index;
+    *cb = {};
+    cb->meta = meta;
+    cb->index = index;
+
+    cb->meta |= META_VALID;
+
+    LOG_TRACE("GPI: callback acquire -> index %d", cb->index);
+
+    return cb;
+}
+
+void gpi_callback_release(gpi_callback *cb) {
+    cb->meta &= ~META_VALID;
+    cb->meta += GEN_INCR;
+
+    cb->next = free_callback;
+    free_callback = cb;
+
+    LOG_TRACE("GPI: callback release -> index %d", cb->index);
+}
+
+gpi_callback *gpi_callback_from_index(int32_t index) {
+    // Do bounds check, this index is usually from user code
+    if (index < 0 || index >= callback_count) {
+        return nullptr;
+    }
+
+    xar_elem_info cb_info = xar_get_elem_info(CB_SHIFT, index);
+    return &callback_chunks[cb_info.chunk_index][cb_info.elem_index];
+}
+
+void gpi_callback_audit() {
+    if (!gpi_debug_enabled) {
+        return;
+    }
+
+    LOG_TRACE("GPI: %d callback objects used", callback_count);
+
+    for (int32_t cursor = 0; cursor < callback_count; cursor++) {
+        gpi_callback *cb = gpi_callback_from_index(cursor);
+
+        if (cb->index != cursor) {
+            LOG_TRACE(
+                "GPI: callback index %d has invalid internal index %d: "
+                "kind: %s, is_parent: %d, removed: %d, impl: %s",
+                cursor, cb->index, cb_kind_to_string(cb->kind),
+                cb->kind & CB_PARENT, cb->removed, cb->impl->get_name_c());
+        }
+        if (cb->meta & META_VALID) {
+            LOG_TRACE(
+                "GPI: callback index %d marked valid: "
+                "kind: %s, is_parent: %d, removed: %d, impl: %s",
+                cursor, cb_kind_to_string(cb->kind), cb->kind & CB_PARENT,
+                cb->removed, cb->impl->get_name_c());
+        }
+    }
+}
+
+const char *cb_kind_to_string(cb_kind kind) {
+    switch (kind & CB_BASIC_KIND) {
+        case CB_READWRITE:
+            return "readwrite";
+        case CB_READONLY:
+            return "readonly";
+        case CB_NEXT_TIMESTEP:
+            return "nexttime";
+        case CB_TIMED:
+            return "timed";
+        case CB_VALUE_CHANGE:
+            return "valuechange";
+        case CB_STARTUP:
+            return "startup";
+        case CB_SHUTDOWN:
+            return "shutdown";
+    }
+    return "<unknown>";
+}
+
+int32_t handle_value_change_callback(gpi_callback *parent_cb) {
+    int32_t any_error = 0;
+    const char *impl_name = parent_cb->impl->get_name_c();
+
+    // LCOV_EXCL_START
+    if (!(parent_cb->kind & CB_PARENT)) {
+        LOG_CRITICAL("%s: valuechange callback index %d not marked as parent!",
+                     impl_name, parent_cb->index);
+    }
+
+    if (!parent_cb->signal) {
+        LOG_CRITICAL(
+            "%s: valuechange callback doesn't have an associated signal!",
+            impl_name);
+        any_error = 1;
+    }
+    // LCOV_EXCL_STOP
+    else {
+        GpiSignalObjHdl *signal =
+            static_cast<GpiSignalObjHdl *>(parent_cb->signal);
+
+        // LCOV_EXCL_START
+        if (signal->m_valuechange_cb != parent_cb) {
+            LOG_CRITICAL(
+                "%s: valuechange callback is not first callback on signal's "
+                "list!",
+                impl_name);
+        }
+        // LCOV_EXCL_STOP
+
+        const char *value_binstr = signal->get_signal_value_binstr();
+
+        // Store the current last registered user callback.
+        // This is the last callback that will be called before returning to the
+        // simulator. Newly registered callbacks will not be processed until the
+        // next value change.
+        gpi_callback *last_cb = parent_cb->last;
+
+        gpi_callback *next_cb = parent_cb->next;
+
+        // Process callbacks
+        bool process_cbs = next_cb != nullptr;
+        while (process_cbs) {
+            bool call_user_func = false;
+            switch (next_cb->edge) {
+                case GPI_VALUE_CHANGE:
+                    call_user_func = true;
+                    break;
+                case GPI_RISING:
+                    call_user_func = !strcmp(value_binstr, "1");
+                    break;
+                case GPI_FALLING:
+                    call_user_func = !strcmp(value_binstr, "0");
+                    break;
+            }
+
+            int32_t error = 0;
+            if (call_user_func) {
+                if (!next_cb->removed) {
+                    if (next_cb->user_cb_func) {
+                        GPI_TO_USER_CB(impl_name);
+                        error = next_cb->user_cb_func(next_cb->user_cb_data);
+                        USER_CB_TO_GPI(impl_name);
+                    } else {
+                        LOG_WARN(
+                            "%s: valuechange user callback index %d has no "
+                            "user function",
+                            impl_name, next_cb->index);
+                    }
+                } else {
+                    LOG_TRACE(
+                        "%s: valuechange user callback index %d is removed",
+                        impl_name, next_cb->index);
+                }
+
+                next_cb->impl->remove_callback(next_cb);
+            }
+
+            if (error) {
+                any_error = error;
+            }
+
+            // Check if the user callback we just processed is the last one.
+            // We need this at the end of the loop, but before going to the next
+            // user callback, so that we don't skip over last_cb.
+            if (next_cb == last_cb) {
+                process_cbs = false;
+            }
+
+            // We're done processing if we hit the end of the list.
+            next_cb = next_cb->next;
+            if (!next_cb) {
+                process_cbs = false;
+            }
+        }
+    }
+    return any_error;
+}
+
+void gpi_mark_valuechange_for_cleanup(gpi_callback *cb) {
+    removed_valuechange_cbs.push_back(cb);
+}
+
+void gpi_cleanup_valuechange_cbs() {
+    // For each child (user) callback in the list, remove it from the list.
+    // If the user callback list is now empty, remove the parent sim callback.
+    // Release the removed user callback to the callback pool
+
+    for (gpi_callback *cb : removed_valuechange_cbs) {
+        LOG_TRACE("%s: valuechange callback cleanup -> index %d",
+                  cb->impl->get_name_c(), cb->index);
+
+        // Only process valid child callbacks.
+        bool valid_cb = cb->meta & META_VALID;
+        if (valid_cb) {
+            gpi_callback *parent_cb = cb->parent;
+            if (parent_cb) {
+                // LCOV_EXCL_START
+                if (!cb->removed) {
+                    LOG_CRITICAL(
+                        "%s: callback index %d in cleanup list but not marked "
+                        "removed",
+                        cb->impl->get_name_c(), cb->index);
+                }
+                // LCOV_EXCL_STOP
+
+                // Remove the callback from the list
+                if (cb->next) {
+                    cb->next->prev = cb->prev;
+                }
+                if (cb->prev) {
+                    cb->prev->next = cb->next;
+                }
+
+                // If we were the last user callback for the parent,
+                // remove the parent and sim callback.
+                if (!parent_cb->next) {
+                    LOG_TRACE(
+                        "%s: parent callback index %d -> removing sim callback "
+                        "%p",
+                        parent_cb->impl->get_name_c(), parent_cb->index,
+                        parent_cb->sim_cb_hdl);
+
+                    parent_cb->impl->remove_callback(parent_cb);
+                } else {
+                    // If the removed callback was the last user callback for
+                    // the parent, replace it with the callback before it in the
+                    // list.
+                    if (parent_cb->last == cb) {
+                        parent_cb->last = cb->prev;
+                    }
+                }
+            }
+            // LCOV_EXCL_START
+            else {
+                LOG_CRITICAL("%s: callback index %d -> no parent callback",
+                             cb->impl->get_name_c(), cb->index);
+            }
+            // LCOV_EXCL_STOP
+
+            gpi_callback_release(cb);
+        }
+    }
+
+    removed_valuechange_cbs.clear();
 }

--- a/src/cocotb/share/lib/gpi/GpiCommon.cpp
+++ b/src/cocotb/share/lib/gpi/GpiCommon.cpp
@@ -129,6 +129,7 @@ void gpi_finalize(void) {
         it->first(it->second);
         LOG_TRACE("User Finalize callback => [ GPI Finalize ]");
     }
+    gpi_callback_audit();
 }
 
 void gpi_check_cleanup(void) {
@@ -659,84 +660,138 @@ gpi_range_dir gpi_get_range_dir(gpi_sim_hdl obj_hdl) {
     return obj_hdl->get_range_dir();
 }
 
-gpi_cb_hdl gpi_register_value_change_callback(int (*gpi_function)(void *),
-                                              void *gpi_cb_data,
-                                              gpi_sim_hdl sig_hdl,
-                                              gpi_edge edge) {
+gpi_hdl gpi_register_value_change_callback(int (*gpi_function)(void *),
+                                           void *gpi_cb_data,
+                                           gpi_sim_hdl sig_hdl, gpi_edge edge) {
     GpiSignalObjHdl *signal_hdl = static_cast<GpiSignalObjHdl *>(sig_hdl);
 
     /* Do something based on int & GPI_RISING | GPI_FALLING */
-    GpiCbHdl *cb_hdl = signal_hdl->register_value_change_callback(
+    gpi_hdl cb_hdl = signal_hdl->register_value_change_callback(
         edge, gpi_function, gpi_cb_data);
-    if (!cb_hdl) {
-        LOG_ERROR("Failed to register a value change callback");
-        return NULL;
-    } else {
-        return cb_hdl;
+
+    if (gpi_hdl_is_nil(cb_hdl)) {
+        LOG_ERROR("Failed to register a valuechange callback");
     }
+    return cb_hdl;
 }
 
-gpi_cb_hdl gpi_register_timed_callback(int (*gpi_function)(void *),
-                                       void *gpi_cb_data, uint64_t time) {
+gpi_hdl gpi_register_timed_callback(int (*gpi_function)(void *),
+                                    void *gpi_cb_data, uint64_t time) {
     // It should not matter which implementation we use for this so just pick
     // the first one
-    GpiCbHdl *cb_hdl = registered_impls[0]->register_timed_callback(
+    gpi_hdl hdl = registered_impls[0]->register_timed_callback(
         time, gpi_function, gpi_cb_data);
-    if (!cb_hdl) {
+    if (gpi_hdl_is_nil(hdl)) {
         LOG_ERROR("Failed to register a timed callback");
-        return NULL;
-    } else {
-        return cb_hdl;
     }
+    return hdl;
 }
 
-gpi_cb_hdl gpi_register_readonly_callback(int (*gpi_function)(void *),
-                                          void *gpi_cb_data) {
+gpi_hdl gpi_register_readonly_callback(int (*gpi_function)(void *),
+                                       void *gpi_cb_data) {
     // It should not matter which implementation we use for this so just pick
     // the first one
-    GpiCbHdl *cb_hdl = registered_impls[0]->register_readonly_callback(
-        gpi_function, gpi_cb_data);
-    if (!cb_hdl) {
+    gpi_hdl hdl = registered_impls[0]->register_readonly_callback(gpi_function,
+                                                                  gpi_cb_data);
+    if (gpi_hdl_is_nil(hdl)) {
         LOG_ERROR("Failed to register a readonly callback");
-        return NULL;
-    } else {
-        return cb_hdl;
     }
+
+    return hdl;
 }
 
-gpi_cb_hdl gpi_register_nexttime_callback(int (*gpi_function)(void *),
-                                          void *gpi_cb_data) {
+gpi_hdl gpi_register_nexttime_callback(int (*gpi_function)(void *),
+                                       void *gpi_cb_data) {
     // It should not matter which implementation we use for this so just pick
     // the first one
-    GpiCbHdl *cb_hdl = registered_impls[0]->register_nexttime_callback(
-        gpi_function, gpi_cb_data);
-    if (!cb_hdl) {
+    gpi_hdl hdl = registered_impls[0]->register_nexttime_callback(gpi_function,
+                                                                  gpi_cb_data);
+    if (gpi_hdl_is_nil(hdl)) {
         LOG_ERROR("Failed to register a nexttime callback");
-        return NULL;
-    } else {
-        return cb_hdl;
     }
+
+    return hdl;
 }
 
-gpi_cb_hdl gpi_register_readwrite_callback(int (*gpi_function)(void *),
-                                           void *gpi_cb_data) {
+gpi_hdl gpi_register_readwrite_callback(int (*gpi_function)(void *),
+                                        void *gpi_cb_data) {
     // It should not matter which implementation we use for this so just pick
     // the first one
-    GpiCbHdl *cb_hdl = registered_impls[0]->register_readwrite_callback(
-        gpi_function, gpi_cb_data);
-    if (!cb_hdl) {
+    gpi_hdl hdl = registered_impls[0]->register_readwrite_callback(gpi_function,
+                                                                   gpi_cb_data);
+    if (gpi_hdl_is_nil(hdl)) {
         LOG_ERROR("Failed to register a readwrite callback");
-        return NULL;
-    } else {
-        return cb_hdl;
     }
+
+    return hdl;
 }
 
-int gpi_remove_cb(gpi_cb_hdl cb_hdl) { return cb_hdl->remove(); }
+int gpi_remove_cb(gpi_hdl cb_hdl) {
+    gpi_callback *cb = gpi_callback_from_index(cb_hdl.index);
 
-void gpi_get_cb_info(gpi_cb_hdl cb_hdl, int (**cb_func)(void *),
-                     void **cb_data) {
-    cb_hdl->get_cb_info(cb_func, cb_data);
+    int error = (!cb);
+
+    if (error) {
+        LOG_ERROR("Attempting remove callback at invalid index %d",
+                  cb_hdl.index);
+    } else if (cb->meta & META_VALID) {
+        uint32_t hdl_gen = cb_hdl.meta & META_GEN;
+        uint32_t cb_gen = cb->meta & META_GEN;
+        if (cb_gen != hdl_gen) {
+            LOG_ERROR(
+                "Attempting to remove callback using out-of-date or invalid "
+                "handle. Handle generation: %d, callback generation: %d",
+                hdl_gen, cb_gen);
+            error = 1;
+        } else {
+            error = cb->impl->remove_callback(cb);
+            if (error) {
+                LOG_ERROR(
+                    "Error removing callback using handle "
+                    "{index: %d, meta: %u}",
+                    cb_hdl.index, cb_hdl.meta);
+            }
+        }
+    }
+    // else callback is already removed and released
+
+    return error;
+}
+
+int gpi_get_cb_info(gpi_hdl cb_hdl, int (**cb_func)(void *), void **cb_data) {
+    gpi_callback *cb = gpi_callback_from_index(cb_hdl.index);
+
+    int error = (!cb);
+
+    if (error) {
+        LOG_ERROR(
+            "Attempting to get callback info for an invalid callback index %d",
+            cb_hdl.index);
+    } else {
+        error = 1;
+        if (cb->meta & META_VALID) {
+            uint32_t hdl_gen = cb_hdl.meta & META_GEN;
+            uint32_t cb_gen = cb->meta & META_GEN;
+            if (cb_gen != hdl_gen) {
+                LOG_ERROR(
+                    "Attempting to get callback info using out-of-date or "
+                    "invalid handle. "
+                    "Handle generation: %d, callback generation: %d",
+                    hdl_gen, cb_gen);
+            } else {
+                error = 0;
+                if (cb_func) {
+                    *cb_func = cb->user_cb_func;
+                }
+                if (cb_data) {
+                    *cb_data = cb->user_cb_data;
+                }
+            }
+        }
+        // else callback is released and handle is invalid
+    }
+
+    return error;
 }
 
 const char *GpiImplInterface::get_name_c() { return m_name.c_str(); }

--- a/src/cocotb/share/lib/gpi/fli/FliCbHdl.cpp
+++ b/src/cocotb/share/lib/gpi/fli/FliCbHdl.cpp
@@ -9,188 +9,399 @@
 #include "./FliImpl.hpp"
 #include "_vendor/fli/mti.h"
 
-// Main re-entry point for callbacks from simulator
+// FLI processes can't be deleted once created.
+// They also are associated with a gpi_callback object
+// that can't be changed after creation.
+// This means that we have to keep the gpi_callback
+// objects in these FLI-specific free lists instead of
+// releasing them back to the global pool.
+static gpi_callback *free_timed_callback = nullptr;
+static gpi_callback *free_read_write_callback = nullptr;
+static gpi_callback *free_read_only_callback = nullptr;
+static gpi_callback *free_next_phase_callback = nullptr;
+static gpi_callback *free_value_change_callback = nullptr;
+
+static void fli_proc_callback_release(gpi_callback *cb) {
+    cb->meta &= ~META_VALID;
+    cb->meta += GEN_INCR;
+
+    switch (cb->kind & CB_BASIC_KIND) {
+        case CB_READWRITE:
+            cb->next = free_read_write_callback;
+            free_read_write_callback = cb;
+            break;
+        case CB_READONLY:
+            cb->next = free_read_only_callback;
+            free_read_only_callback = cb;
+            break;
+        case CB_NEXT_TIMESTEP:
+            cb->next = free_next_phase_callback;
+            free_next_phase_callback = cb;
+            break;
+        case CB_TIMED:
+            cb->next = free_timed_callback;
+            free_timed_callback = cb;
+            break;
+        case CB_VALUE_CHANGE:
+            cb->next = free_value_change_callback;
+            free_value_change_callback = cb;
+            break;
+
+        case CB_STARTUP:
+            LOG_CRITICAL("FLI: Attempting to release startup callback!");
+            break;
+        case CB_SHUTDOWN:
+            LOG_CRITICAL("FLI: Attempting to release shutdown callback!");
+            break;
+    }
+
+    LOG_TRACE("FLI: callback release -> %s callback index %d to free list",
+              cb_kind_to_string(cb->kind), cb->index);
+}
+
+// Main entry point for callbacks from simulator
 void handle_fli_callback(void *data) {
-    SIM_TO_GPI(FLI, "callback");
+    SIM_TO_GPI("FLI", "callback");
 
-    // TODO Add why?
-    fflush(stderr);
+    gpi_callback *cb = (gpi_callback *)data;
 
-    FliCbHdl *cb_hdl = (FliCbHdl *)data;
-
-    int error = (!cb_hdl);
+    int32_t error = (!cb);
     // LCOV_EXCL_START
     if (error) {
         LOG_CRITICAL("FLI: Callback data corrupted: ABORTING");
     }
     // LCOV_EXCL_STOP
 
+    bool valid_cb = false;
     if (!error) {
-        GPI_TO_USER_CB(FLI);
-        error = cb_hdl->run();
-        USER_CB_TO_GPI(FLI);
+        valid_cb = cb->meta & META_VALID;
+
+        // LCOV_EXCL_START
+        if (!valid_cb) {
+            LOG_CRITICAL("FLI: Callback index %d not marked valid: ABORTING",
+                         cb->index);
+            error = 1;
+        }
+        // LCOV_EXCL_STOP
     }
+
+    if (valid_cb) {
+        if (!cb->removed) {
+            if ((cb->kind & CB_BASIC_KIND) == CB_VALUE_CHANGE) {
+                error = handle_value_change_callback(cb);
+            } else {
+                if (cb->user_cb_func) {
+                    GPI_TO_USER_CB("FLI");
+                    error = cb->user_cb_func(cb->user_cb_data);
+                    USER_CB_TO_GPI("FLI");
+                } else {
+                    LOG_WARN("FLI: %s callback has no user callback function",
+                             cb_kind_to_string(cb->kind));
+                }
+            }
+        } else {
+            LOG_TRACE("FLI: %s callback index %d is removed",
+                      cb_kind_to_string(cb->kind), cb->index);
+        }
+
+        switch (cb->kind & CB_BASIC_KIND) {
+            case CB_TIMED:
+            case CB_READWRITE:
+            case CB_READONLY:
+            case CB_NEXT_TIMESTEP:
+                fli_proc_callback_release(cb);
+                break;
+            case CB_STARTUP:
+            case CB_SHUTDOWN:
+                gpi_callback_release(cb);
+                break;
+            case CB_VALUE_CHANGE:
+                // Do nothing here.
+                // If there are no more user callbacks, the parent callback
+                // will be desensitized and released in the cleanup below.
+                // Otherwise we leave it to fire again.
+                break;
+        }
+    }
+
+    gpi_cleanup_valuechange_cbs();
 
     if (error) {
         gpi_end_of_sim_time();
     }
 
-    GPI_TO_SIM(FLI);
+    GPI_TO_SIM("FLI");
 }
 
-int FliTimedCbHdl::arm() {
-    // These are reused, so we need to reset m_removed.
-    m_removed = false;
-#if defined(__LP64__) || defined(_WIN64)
-    mti_ScheduleWakeup64(m_proc_hdl, static_cast<mtiTime64T>(m_time));
-#else
-    mtiTime64T m_time_union_ps;
-    MTI_TIME64_ASGN(m_time_union_ps, (mtiInt32T)((m_time) >> 32),
-                    (mtiUInt32T)(m_time));
-    mti_ScheduleWakeup64(m_proc_hdl, m_time_union_ps);
-#endif
-    return 0;
-}
+static gpi_callback *fli_proc_callback_acquire(cb_kind kind) {
+    gpi_callback **cb_list = nullptr;
+    int priority = 0;
 
-int FliTimedCbHdl::run() {
-    int res = 0;
-    if (!m_removed) {
-        // Prevent the callback from calling up if it's been removed.
-        res = m_cb_func(m_cb_data);
-    }
-    // Don't delete, but release back to the appropriate cache to be reused.
-    release();
-    return res;
-}
-
-int FliTimedCbHdl::remove() {
-    // mti_ScheduleWakeup callbacks can't be cancelled, so we mark the callback
-    // as removed and let it fire. When it fires, this flag prevents it from
-    // calling up and then releases the callback back to the appropriate cache
-    // to be reused.
-    m_removed = true;
-    return 0;
-}
-
-int FliSignalCbHdl::arm() {
-    mti_Sensitize(m_proc_hdl, m_signal->get_handle<mtiSignalIdT>(), MTI_EVENT);
-    return 0;
-}
-
-int FliSignalCbHdl::run() {
-    bool pass = false;
-    switch (m_edge) {
-        case GPI_RISING: {
-            pass = !strcmp(m_signal->get_signal_value_binstr(), "1");
+    switch (kind & CB_BASIC_KIND) {
+        case CB_READWRITE:
+            cb_list = &free_read_write_callback;
+            priority = MTI_PROC_SYNCH;
             break;
-        }
-        case GPI_FALLING: {
-            pass = !strcmp(m_signal->get_signal_value_binstr(), "0");
+        case CB_READONLY:
+            cb_list = &free_read_only_callback;
+            priority = MTI_PROC_POSTPONED;
             break;
-        }
-        case GPI_VALUE_CHANGE: {
-            pass = true;
+        case CB_NEXT_TIMESTEP:
+            cb_list = &free_next_phase_callback;
+            priority = MTI_PROC_IMMEDIATE;
             break;
-        }
+        case CB_TIMED:
+            cb_list = &free_timed_callback;
+            priority = MTI_PROC_IMMEDIATE;
+            break;
+        case CB_VALUE_CHANGE:
+            cb_list = &free_value_change_callback;
+            priority = MTI_PROC_NORMAL;
+            break;
+
+        case CB_STARTUP:
+            LOG_CRITICAL("FLI: Attempting to acquire startup callback!");
+            return nullptr;
+            break;
+        case CB_SHUTDOWN:
+            LOG_CRITICAL("FLI: Attempting to acquire shutdown callback!");
+            return nullptr;
+            break;
     }
 
-    int res = 0;
-    if (pass) {
-        res = m_cb_func(m_cb_data);
+    gpi_callback *cb = *cb_list;
 
-        // Don't delete, but desensitize the process from the signal change and
-        // release back to the appropriate cache to be reused.
-        mti_Desensitize(m_proc_hdl);
-        release();
-    }  // else don't remove and let it fire again.
+    if (cb) {
+        *cb_list = (*cb_list)->next;
+        cb->meta |= META_VALID;
 
-    return res;
-}
+        LOG_TRACE(
+            "FLI: callback acquire -> %s callback index %d from free list with "
+            "sim callback %p",
+            cb_kind_to_string(cb->kind), cb->index, cb->sim_cb_hdl);
+    } else {
+        cb = gpi_callback_acquire();
+        mtiProcessIdT mti_proc = mti_CreateProcessWithPriority(
+            nullptr, handle_fli_callback, cb, (mtiProcessPriorityT)priority);
 
-int FliSignalCbHdl::remove() {
-    // Don't delete, but desensitize the process from the signal change and
-    // release back to the appropriate cache to be reused.
-    mti_Desensitize(m_proc_hdl);
-    release();
-    return 0;
-}
+        cb->sim_cb_hdl = mti_proc;
 
-int FliSimPhaseCbHdl::arm() {
-    mti_ScheduleWakeup(m_proc_hdl, 0);
-    m_removed = false;
-    return 0;
-}
-
-int FliSimPhaseCbHdl::run() {
-    int res = 0;
-    if (!m_removed) {
-        // Prevent the callback from calling up if it's been removed.
-        res = m_cb_func(m_cb_data);
+        LOG_TRACE(
+            "FLI: callback acquire -> new %s callback index %d with sim "
+            "callback %p",
+            cb_kind_to_string(cb->kind), cb->index, cb->sim_cb_hdl);
     }
-    // Don't delete, but release back to the appropriate cache to be reused.
-    release();
-    return res;
+
+    return cb;
 }
 
-int FliSimPhaseCbHdl::remove() {
-    // mti_ScheduleWakeup callbacks can't be cancelled, so we mark the callback
-    // as removed and let it fire. When it fires, this flag prevents it from
-    // calling up and then releases the callback back to the appropriate cache
-    // to be reused.
-    m_removed = true;
+gpi_hdl FliImpl::register_timed_callback(uint64_t time, int (*cb_func)(void *),
+                                         void *cb_data) {
+    gpi_hdl ret_hdl = gpi_nil_hdl;
+
+    gpi_callback *cb = fli_proc_callback_acquire(CB_TIMED);
+
+    mti_ScheduleWakeup64(static_cast<mtiProcessIdT>(cb->sim_cb_hdl),
+                         static_cast<mtiTime64T>(time));
+
+    cb->impl = this;
+    cb->user_cb_func = cb_func;
+    cb->user_cb_data = cb_data;
+    cb->kind = CB_TIMED;
+
+    ret_hdl.index = cb->index;
+    ret_hdl.meta = cb->meta;
+
+    return ret_hdl;
+}
+
+gpi_hdl FliImpl::register_readonly_callback(int (*cb_func)(void *),
+                                            void *cb_data) {
+    gpi_hdl ret_hdl = gpi_nil_hdl;
+
+    gpi_callback *cb = fli_proc_callback_acquire(CB_READONLY);
+
+    mti_ScheduleWakeup(static_cast<mtiProcessIdT>(cb->sim_cb_hdl), 0);
+
+    cb->impl = this;
+    cb->user_cb_func = cb_func;
+    cb->user_cb_data = cb_data;
+    cb->kind = CB_READONLY;
+
+    ret_hdl.index = cb->index;
+    ret_hdl.meta = cb->meta;
+
+    return ret_hdl;
+}
+
+gpi_hdl FliImpl::register_readwrite_callback(int (*cb_func)(void *),
+                                             void *cb_data) {
+    gpi_hdl ret_hdl = gpi_nil_hdl;
+
+    gpi_callback *cb = fli_proc_callback_acquire(CB_READWRITE);
+
+    mti_ScheduleWakeup(static_cast<mtiProcessIdT>(cb->sim_cb_hdl), 0);
+
+    cb->impl = this;
+    cb->user_cb_func = cb_func;
+    cb->user_cb_data = cb_data;
+    cb->kind = CB_READWRITE;
+
+    ret_hdl.index = cb->index;
+    ret_hdl.meta = cb->meta;
+
+    return ret_hdl;
+}
+
+gpi_hdl FliImpl::register_nexttime_callback(int (*cb_func)(void *),
+                                            void *cb_data) {
+    gpi_hdl ret_hdl = gpi_nil_hdl;
+
+    gpi_callback *cb = fli_proc_callback_acquire(CB_NEXT_TIMESTEP);
+
+    mti_ScheduleWakeup(static_cast<mtiProcessIdT>(cb->sim_cb_hdl), 0);
+
+    cb->impl = this;
+    cb->user_cb_func = cb_func;
+    cb->user_cb_data = cb_data;
+    cb->kind = CB_NEXT_TIMESTEP;
+
+    ret_hdl.index = cb->index;
+    ret_hdl.meta = cb->meta;
+
+    return ret_hdl;
+}
+
+int FliImpl::remove_callback(gpi_callback *cb) {
+    if (cb->removed) {
+        return 0;
+    }
+
+    // Mark as removed
+    cb->removed = true;
+
+    switch (cb->kind & CB_BASIC_KIND) {
+        case CB_READWRITE:
+        case CB_READONLY:
+        case CB_NEXT_TIMESTEP:
+        case CB_TIMED: {
+            // mti_ScheduleWakeup callbacks can't be cancelled,
+            // so we mark it removed and let it fire.
+            // When it fires, this flag prevents the user callback from
+            // being called and then the gpi_callback is released to the
+            // appropriate free list to be reused.
+            break;
+        }
+        case CB_STARTUP: {
+            mti_RemoveLoadDoneCB(handle_fli_callback, cb);
+            gpi_callback_release(cb);
+            break;
+        }
+        case CB_SHUTDOWN: {
+            mti_RemoveQuitCB(handle_fli_callback, cb);
+            gpi_callback_release(cb);
+            break;
+        }
+        case CB_VALUE_CHANGE: {
+            // There are two types of value change callbacks to remove.
+            // 1. User callbacks that are children of a parent callback
+            // 2. Parent callbacks that are associated with the simulator
+            // callback
+            //
+            // For user callbacks, we mark them for cleanup later,
+            // before the sim callback returns.
+            // In the later cleanup, if all child callbacks have been removed
+            // and marked for cleanup,
+            // this function will get called on the parent callback.
+            // In that case, we desensitize and release the FLI object,
+            // and clear the parent callback from the associated signal object.
+
+            if (cb->kind & CB_PARENT) {
+                mti_Desensitize(static_cast<mtiProcessIdT>(cb->sim_cb_hdl));
+                fli_proc_callback_release(cb);
+
+                cb->signal->m_valuechange_cb = nullptr;
+            } else {
+                // Don't release it here, just mark it to be cleaned up before
+                // the callback returns
+                gpi_mark_valuechange_for_cleanup(cb);
+            }
+            break;
+        }
+
+        default:
+            break;
+    }
+
     return 0;
 }
 
-void FliSignalCbHdl::release() {
-    dynamic_cast<FliImpl *>(m_impl)->m_value_change_cache.release(this);
-}
+gpi_hdl FliSignalObjHdl::register_value_change_callback(gpi_edge edge,
+                                                        int (*cb_func)(void *),
+                                                        void *cb_data) {
+    gpi_hdl ret_hdl = gpi_nil_hdl;
 
-void FliTimedCbHdl::release() {
-    dynamic_cast<FliImpl *>(m_impl)->m_timer_cache.release(this);
-}
+    if (!m_is_var) {
+        gpi_callback *user_cb = gpi_callback_acquire();
 
-void FliReadOnlyCbHdl::release() {
-    dynamic_cast<FliImpl *>(m_impl)->m_read_only_cache.release(this);
-}
+        bool valid_cb = true;
+        if (m_valuechange_cb) {
+            // If there is already a sim callback,
+            // add a user callback to the end of the list.
+            user_cb->impl = m_impl;
+            user_cb->parent = m_valuechange_cb;
+            user_cb->user_cb_func = cb_func;
+            user_cb->user_cb_data = cb_data;
+            user_cb->edge = edge;
+            user_cb->kind = CB_VALUE_CHANGE;
 
-void FliReadWriteCbHdl::release() {
-    dynamic_cast<FliImpl *>(m_impl)->m_read_write_cache.release(this);
-}
+            // Update parent
+            m_valuechange_cb->last->next = user_cb;
+            user_cb->prev = m_valuechange_cb->last;
+            m_valuechange_cb->last = user_cb;
 
-void FliNextPhaseCbHdl::release() {
-    dynamic_cast<FliImpl *>(m_impl)->m_next_phase_cache.release(this);
-}
+            LOG_TRACE(
+                "FLI: new valuechange child callback index %d added to "
+                "existing parent callback index %d",
+                user_cb->index, m_valuechange_cb->index);
+        } else {
+            // If there is no sim callback,
+            // register one with a parent callback object and start the user
+            // callback list.
 
-int FliStartupCbHdl::arm() {
-    mti_AddLoadDoneCB(handle_fli_callback, (void *)this);
-    return 0;
-}
+            gpi_callback *parent_cb =
+                fli_proc_callback_acquire(CB_VALUE_CHANGE);
 
-int FliStartupCbHdl::run() {
-    int res = m_cb_func(m_cb_data);
-    delete this;
-    return res;
-}
+            mti_Sensitize(static_cast<mtiProcessIdT>(parent_cb->sim_cb_hdl),
+                          get_handle<mtiSignalIdT>(), MTI_EVENT);
 
-int FliStartupCbHdl::remove() {
-    mti_RemoveLoadDoneCB(handle_fli_callback, (void *)this);
-    delete this;
-    return 0;
-}
+            parent_cb->impl = m_impl;
+            parent_cb->next = user_cb;
+            parent_cb->last = user_cb;
+            parent_cb->signal = this;
+            parent_cb->kind = CB_VALUE_CHANGE | CB_PARENT;
 
-int FliShutdownCbHdl::arm() {
-    mti_AddQuitCB(handle_fli_callback, (void *)this);
-    return 0;
-}
+            user_cb->impl = m_impl;
+            user_cb->parent = parent_cb;
+            user_cb->prev = parent_cb;
+            user_cb->user_cb_func = cb_func;
+            user_cb->user_cb_data = cb_data;
+            user_cb->edge = edge;
+            user_cb->kind = CB_VALUE_CHANGE;
 
-int FliShutdownCbHdl::run() {
-    int res = m_cb_func(m_cb_data);
-    delete this;
-    return res;
-}
+            m_valuechange_cb = parent_cb;
 
-int FliShutdownCbHdl::remove() {
-    mti_RemoveQuitCB(handle_fli_callback, (void *)this);
-    delete this;
-    return 0;
+            LOG_TRACE(
+                "FLI: sensitizing sim callback %p for valuechange parent "
+                "callback index %d and adding new child callback index %d",
+                parent_cb->sim_cb_hdl, parent_cb->index, user_cb->index);
+        }
+
+        if (valid_cb) {
+            ret_hdl.index = user_cb->index;
+            ret_hdl.meta = user_cb->meta;
+        }
+    }
+
+    return ret_hdl;
 }

--- a/src/cocotb/share/lib/gpi/fli/FliImpl.cpp
+++ b/src/cocotb/share/lib/gpi/fli/FliImpl.cpp
@@ -18,7 +18,8 @@
 #include "_vendor/tcl/tcl.h"
 
 void FliImpl::sim_end() {
-    m_sim_finish_cb->remove();
+    remove_callback(m_sim_finish_cb);
+
     if (mti_NowUpper() == 0 && mti_Now() == 0 && mti_Delta() == 0) {
         mti_Quit();
     } else {
@@ -398,7 +399,7 @@ GpiObjHdl *FliImpl::get_child_by_index(int32_t index, GpiObjHdl *parent) {
                obj_type == GPI_ARRAY || obj_type == GPI_STRING) {
         FliValueObjHdl *fli_obj = reinterpret_cast<FliValueObjHdl *>(parent);
 
-        LOG_DEBUG("Looking for index %u from %s", index,
+        LOG_DEBUG("Looking for index %d from %s", index,
                   parent->get_name_str());
 
         if ((hdl = fli_obj->get_sub_hdl(index)) == NULL) {
@@ -590,65 +591,6 @@ error:
                   mti_GetRegionName(root));
     }
     return NULL;
-}
-
-GpiCbHdl *FliImpl::register_timed_callback(uint64_t time,
-                                           int (*cb_func)(void *),
-                                           void *cb_data) {
-    // get timer from cache
-    auto cb_hdl = m_timer_cache.acquire();
-    cb_hdl->set_time(time);
-    int err = cb_hdl->arm();
-    // LCOV_EXCL_START
-    if (err) {
-        m_timer_cache.release(cb_hdl);
-        return NULL;
-    }
-    // LCOV_EXCL_STOP
-    cb_hdl->set_cb_info(cb_func, cb_data);
-    return cb_hdl;
-}
-
-GpiCbHdl *FliImpl::register_readonly_callback(int (*cb_func)(void *),
-                                              void *cb_data) {
-    auto cb_hdl = m_read_only_cache.acquire();
-    int err = cb_hdl->arm();
-    // LCOV_EXCL_START
-    if (err) {
-        m_read_only_cache.release(cb_hdl);
-        return NULL;
-    }
-    // LCOV_EXCL_STOP
-    cb_hdl->set_cb_info(cb_func, cb_data);
-    return cb_hdl;
-}
-
-GpiCbHdl *FliImpl::register_readwrite_callback(int (*cb_func)(void *),
-                                               void *cb_data) {
-    auto cb_hdl = m_read_write_cache.acquire();
-    int err = cb_hdl->arm();
-    // LCOV_EXCL_START
-    if (err) {
-        m_read_write_cache.release(cb_hdl);
-        return NULL;
-    }
-    // LCOV_EXCL_STOP
-    cb_hdl->set_cb_info(cb_func, cb_data);
-    return cb_hdl;
-}
-
-GpiCbHdl *FliImpl::register_nexttime_callback(int (*cb_func)(void *),
-                                              void *cb_data) {
-    auto cb_hdl = m_next_phase_cache.acquire();
-    int err = cb_hdl->arm();
-    // LCOV_EXCL_START
-    if (err) {
-        m_next_phase_cache.release(cb_hdl);
-        return NULL;
-    }
-    // LCOV_EXCL_STOP
-    cb_hdl->set_cb_info(cb_func, cb_data);
-    return cb_hdl;
 }
 
 GpiIterator *FliImpl::iterate_handle(GpiObjHdl *obj_hdl,
@@ -1120,30 +1062,22 @@ static int shutdown_callback(void *) {
 }
 
 void FliImpl::main() noexcept {
-    auto startup_cb = new FliStartupCbHdl(this);
-    auto err = startup_cb->arm();
-    // LCOV_EXCL_START
-    if (err) {
-        LOG_CRITICAL(
-            "FLI: Unable to register startup callback! Simulation will end.");
-        delete startup_cb;
-        exit(1);
-    }
-    // LCOV_EXCL_STOP
-    startup_cb->set_cb_info(startup_callback, nullptr);
+    gpi_callback *startup_cb = gpi_callback_acquire();
 
-    auto shutdown_cb = new FliShutdownCbHdl(this);
-    err = shutdown_cb->arm();
-    // LCOV_EXCL_START
-    if (err) {
-        LOG_CRITICAL(
-            "FLI: Unable to register shutdown callback! Simulation will end.");
-        startup_cb->remove();
-        delete shutdown_cb;
-        exit(1);
-    }
-    // LCOV_EXCL_STOP
-    shutdown_cb->set_cb_info(shutdown_callback, nullptr);
+    mti_AddLoadDoneCB(handle_fli_callback, startup_cb);
+
+    startup_cb->impl = this;
+    startup_cb->user_cb_func = startup_callback;
+    startup_cb->kind = CB_STARTUP;
+
+    gpi_callback *shutdown_cb = gpi_callback_acquire();
+
+    mti_AddQuitCB(handle_fli_callback, shutdown_cb);
+
+    shutdown_cb->impl = this;
+    shutdown_cb->user_cb_func = shutdown_callback;
+    shutdown_cb->kind = CB_SHUTDOWN;
+
     m_sim_finish_cb = shutdown_cb;
 
     gpi_register_impl(this);

--- a/src/cocotb/share/lib/gpi/fli/FliImpl.hpp
+++ b/src/cocotb/share/lib/gpi/fli/FliImpl.hpp
@@ -24,150 +24,8 @@
 class FliImpl;
 class FliSignalObjHdl;
 
-class FliCbHdl : public GpiCbHdl {
-  public:
-    using GpiCbHdl::GpiCbHdl;
-};
-
-// In FLI some callbacks require us to register a process
-// We use a subclass to track the process state related to the callback
-class FliProcessCbHdl : public FliCbHdl {
-  public:
-    FliProcessCbHdl(GpiImplInterface *impl) : FliCbHdl(impl) {}
-
-    void set_mti_proc(mtiProcessIdT mti_proc) noexcept {
-        m_proc_hdl = mti_proc;
-    }
-
-    virtual void release() = 0;
-
-  protected:
-    mtiProcessIdT m_proc_hdl;
-};
-
-/** Maintains a cache of FliProcessCbHdl objects which can be reused.
- *
- * MTI Processes cannot be destroyed. So we never delete FliProcessCbHdl objects
- * and their MTI Processes and instead reuse them to prevent runaway leaks.
- *
- * We use the queue with LIFO behavior so recently used objects are reused first
- * leveraging cache locality.
- */
-template <typename FliProcessCbHdlType, int priority>
-class FliProcessCbHdlCache {
-  public:
-    FliProcessCbHdlCache(FliImpl *impl) : m_impl(impl) {}
-
-    FliProcessCbHdlType *acquire() {
-        void handle_fli_callback(void *);
-
-        if (!free_list.empty()) {
-            FliProcessCbHdlType *cb_hdl = free_list.back();
-            free_list.pop_back();
-            return cb_hdl;
-        } else {
-            auto cb_hdl = new FliProcessCbHdlType(m_impl);
-            auto mti_proc = mti_CreateProcessWithPriority(
-                nullptr, handle_fli_callback, cb_hdl,
-                (mtiProcessPriorityT)priority);
-            cb_hdl->set_mti_proc(mti_proc);
-            return cb_hdl;
-        }
-    }
-    void release(FliProcessCbHdlType *cb_hdl) { free_list.push_back(cb_hdl); }
-
-  private:
-    FliImpl *m_impl;
-    std::vector<FliProcessCbHdlType *> free_list;
-};
-
-class FliSignalCbHdl : public FliProcessCbHdl {
-  public:
-    using FliProcessCbHdl::FliProcessCbHdl;
-
-    /** Set the signal and edge used by arm()
-     *
-     * MUST BE CALLED BEFORE arm()!
-     */
-    void set_signal_and_edge(FliSignalObjHdl *signal, gpi_edge edge) noexcept {
-        m_signal = signal;
-        m_edge = edge;
-    };
-    int arm() override;
-    int run() override;
-    int remove() override;
-    void release() override;
-
-  private:
-    FliSignalObjHdl *m_signal;
-    gpi_edge m_edge;
-};
-
-class FliSimPhaseCbHdl : public FliProcessCbHdl {
-  public:
-    using FliProcessCbHdl::FliProcessCbHdl;
-    int arm() override;
-    int run() override;
-    int remove() override;
-
-  private:
-    bool m_removed;
-};
-
-class FliReadWriteCbHdl : public FliSimPhaseCbHdl {
-  public:
-    using FliSimPhaseCbHdl::FliSimPhaseCbHdl;
-    void release() override;
-};
-
-class FliNextPhaseCbHdl : public FliSimPhaseCbHdl {
-  public:
-    using FliSimPhaseCbHdl::FliSimPhaseCbHdl;
-    void release() override;
-};
-
-class FliReadOnlyCbHdl : public FliSimPhaseCbHdl {
-  public:
-    using FliSimPhaseCbHdl::FliSimPhaseCbHdl;
-    void release() override;
-};
-
-class FliStartupCbHdl : public FliCbHdl {
-  public:
-    FliStartupCbHdl(GpiImplInterface *impl) : FliCbHdl(impl) {}
-
-    int arm() override;
-    int run() override;
-    int remove() override;
-};
-
-class FliShutdownCbHdl : public FliCbHdl {
-  public:
-    FliShutdownCbHdl(GpiImplInterface *impl) : FliCbHdl(impl) {}
-
-    int arm() override;
-    int run() override;
-    int remove() override;
-};
-
-class FliTimedCbHdl : public FliProcessCbHdl {
-  public:
-    using FliProcessCbHdl::FliProcessCbHdl;
-
-    /** Set the time used by arm()
-     *
-     * MUST BE CALLED BEFORE arm()!
-     */
-    void set_time(uint64_t time) noexcept { m_time = time; }
-    int arm() override;
-    int run() override;
-    int remove() override;
-    void release() override;
-
-  private:
-    uint64_t m_time;
-    bool m_removed;
-};
+// Main entry point for callbacks from simulator
+void handle_fli_callback(void *data);
 
 // Object Handles
 class FliObj {
@@ -206,9 +64,9 @@ class FliSignalObjHdl : public GpiSignalObjHdl, public FliObj {
 
     int initialise(const std::string &name,
                    const std::string &fq_name) override;
-    GpiCbHdl *register_value_change_callback(gpi_edge edge,
-                                             int (*function)(void *),
-                                             void *cb_data) override;
+    gpi_hdl register_value_change_callback(gpi_edge edge,
+                                           int (*function)(void *),
+                                           void *cb_data) override;
 
     bool is_variable() { return m_is_var; }
 
@@ -415,13 +273,7 @@ class FliIterator : public GpiIterator {
 
 class FliImpl : public GpiImplInterface {
   public:
-    FliImpl(const std::string &name)
-        : GpiImplInterface(name),
-          m_timer_cache(this),
-          m_value_change_cache(this),
-          m_read_write_cache(this),
-          m_read_only_cache(this),
-          m_next_phase_cache(this) {}
+    FliImpl(const std::string &name) : GpiImplInterface(name) {}
 
     /* Sim related */
     void sim_end() override;
@@ -441,14 +293,15 @@ class FliImpl : public GpiImplInterface {
                                 gpi_iterator_sel type) override;
 
     /* Callback related, these may (will) return the same handle*/
-    GpiCbHdl *register_timed_callback(uint64_t time, int (*function)(void *),
-                                      void *cb_data) override;
-    GpiCbHdl *register_readonly_callback(int (*function)(void *),
-                                         void *cb_data) override;
-    GpiCbHdl *register_nexttime_callback(int (*function)(void *),
-                                         void *cb_data) override;
-    GpiCbHdl *register_readwrite_callback(int (*function)(void *),
-                                          void *cb_data) override;
+    gpi_hdl register_timed_callback(uint64_t time, int (*function)(void *),
+                                    void *cb_data) override;
+    gpi_hdl register_readonly_callback(int (*function)(void *),
+                                       void *cb_data) override;
+    gpi_hdl register_nexttime_callback(int (*function)(void *),
+                                       void *cb_data) override;
+    gpi_hdl register_readwrite_callback(int (*function)(void *),
+                                        void *cb_data) override;
+    int remove_callback(gpi_callback *cb) override;
 
     /* Method to provide strings from operation types */
     GpiObjHdl *create_gpi_obj_from_handle(void *hdl, const std::string &name,
@@ -469,9 +322,9 @@ class FliImpl : public GpiImplInterface {
     bool isTypeSignal(int type, int full_type);
 
   private:
-    // We store the shutdown callback handle here so sim_end() can remove() it
-    // if it's called.
-    FliShutdownCbHdl *m_sim_finish_cb;
+    // We store the shutdown callback handle here so that if sim_end() is
+    // called, it can be removed.
+    gpi_callback *m_sim_finish_cb;
 
     // Cache simulator info
     std::string m_product;
@@ -480,24 +333,7 @@ class FliImpl : public GpiImplInterface {
     std::vector<std::string> m_argv_storage;
     char const **m_argv = nullptr;
 
-    // Caches for each type of callback handle. This must be associated with the
-    // FliImpl rather than be static member of the callback handle type because
-    // each callback handle is associated with an FliImpl.
-    // TODO remove the FliImpl association from the callback handle types then
-    // move these to static fields in the callback handle types.
-    FliProcessCbHdlCache<FliTimedCbHdl, MTI_PROC_IMMEDIATE> m_timer_cache;
-    FliProcessCbHdlCache<FliSignalCbHdl, MTI_PROC_NORMAL> m_value_change_cache;
-    FliProcessCbHdlCache<FliReadWriteCbHdl, MTI_PROC_SYNCH> m_read_write_cache;
-    FliProcessCbHdlCache<FliReadOnlyCbHdl, MTI_PROC_POSTPONED>
-        m_read_only_cache;
-    FliProcessCbHdlCache<FliNextPhaseCbHdl, MTI_PROC_IMMEDIATE>
-        m_next_phase_cache;
     friend FliSignalObjHdl;
-    friend FliTimedCbHdl;
-    friend FliSignalCbHdl;
-    friend FliReadWriteCbHdl;
-    friend FliReadOnlyCbHdl;
-    friend FliNextPhaseCbHdl;
 };
 
 #endif /*COCOTB_FLI_IMPL_H_ */

--- a/src/cocotb/share/lib/gpi/fli/FliObjHdl.cpp
+++ b/src/cocotb/share/lib/gpi/fli/FliObjHdl.cpp
@@ -17,27 +17,6 @@
 using std::abs;
 using std::to_string;
 
-GpiCbHdl *FliSignalObjHdl::register_value_change_callback(
-    gpi_edge edge, int (*cb_func)(void *), void *cb_data) {
-    if (m_is_var) {
-        return NULL;
-    }
-    // TODO The dynamic cast here is a good reason to not declare members in
-    // base classes.
-    auto &cache = dynamic_cast<FliImpl *>(m_impl)->m_value_change_cache;
-    auto cb = cache.acquire();
-    cb->set_signal_and_edge(this, edge);
-    auto err = cb->arm();
-    // LCOV_EXCL_START
-    if (err) {
-        cache.release(cb);
-        return NULL;
-    }
-    // LCOV_EXCL_STOP
-    cb->set_cb_info(cb_func, cb_data);
-    return cb;
-}
-
 int FliObjHdl::initialise(const std::string &name, const std::string &fq_name) {
     bool is_signal =
         (get_acc_type() == accSignal || get_acc_full_type() == accAliasSignal);

--- a/src/cocotb/share/lib/gpi/gpi_priv.hpp
+++ b/src/cocotb/share/lib/gpi/gpi_priv.hpp
@@ -19,10 +19,73 @@
 #define GPI_EXPORT COCOTB_IMPORT
 #endif
 
+// Callback kind
+// Bottom byte is basic kind
+// Upper bits are for flags
+typedef uint16_t cb_kind;
+enum cb_kind_ : uint16_t {
+    CB_TIMED,
+    CB_VALUE_CHANGE,
+    CB_READONLY,
+    CB_NEXT_TIMESTEP,
+    CB_READWRITE,
+    CB_STARTUP,
+    CB_SHUTDOWN,
+
+    CB_PARENT = 1 << 8,
+};
+
+#define CB_BASIC_KIND 0xFF
+
+GPI_EXPORT const char *cb_kind_to_string(cb_kind kind);
+
+// handle/object metadata
+// Bit 0 is valid bit for tracking if callback object is acquired or released
+// The rest are generation for handle validity
+typedef uint32_t meta32;
+#define GEN_INCR (1 << 1)
+#define META_GEN 0xFFFFFFFE
+#define META_VALID 0x1U
+
 class GpiCbHdl;
 class GpiImplInterface;
 class GpiIterator;
-class GpiCbHdl;
+class GpiSignalObjHdl;
+
+struct gpi_callback {
+    // Callback kind
+    cb_kind kind;
+
+    // Removed (valid callback but not to be processed / called)
+    bool removed;
+
+    // Metadata (generation, validity)
+    meta32 meta;
+
+    // GPI implementation
+    GpiImplInterface *impl;
+
+    // Simulator callback object handle
+    // Null when this is a child callback
+    void *sim_cb_hdl;
+
+    // Pointers to manage parent and child (user) callbacks
+    gpi_callback *parent;
+    gpi_callback *next;
+    gpi_callback *prev;
+    gpi_callback *last;
+
+    // User callback
+    int32_t (*user_cb_func)(void *);
+    void *user_cb_data;
+
+    // ValueChange callbacks
+    GpiSignalObjHdl *signal;
+    gpi_edge edge;
+
+    // Index in the callback pool
+    int32_t index;
+};
 
 /* Base GPI class others are derived from */
 class GPI_EXPORT GpiHdl {
@@ -131,69 +194,21 @@ class GPI_EXPORT GpiSignalObjHdl : public GpiObjHdl {
                                      gpi_set_action action) = 0;
     virtual int set_signal_value_binstr(std::string &value,
                                         gpi_set_action action) = 0;
-    // virtual GpiCbHdl monitor_value(bool rising_edge) = 0; this was for the
-    // triggers
-    // but the explicit ones are probably better
 
-    virtual GpiCbHdl *register_value_change_callback(
-        gpi_edge edge, int (*gpi_function)(void *), void *gpi_cb_data) = 0;
+    virtual gpi_hdl register_value_change_callback(gpi_edge edge,
+                                                   int (*gpi_function)(void *),
+                                                   void *gpi_cb_data) = 0;
+
+    // Value change callback is associated with sim callback object.
+    gpi_callback *m_valuechange_cb = nullptr;
 };
 
-/* GPI Callback handle */
-// To set a callback it needs the signal to do this on,
-// vpiHandle/vhpiHandleT for instance. The
-class GPI_EXPORT GpiCbHdl : public GpiHdl {
-  public:
-    GpiCbHdl() = delete;
-    GpiCbHdl(GpiImplInterface *impl) : GpiHdl(impl) {}
-
-    // TODO Some of these routines don't need to be declared here. Only remove()
-    // and get_cb_info() need to. In fact, declaring these here means we can't
-    // do things like pass arguments to arm().
-
-    /** Set user callback info
-     *
-     * Not on init to prevent having to pass around the arguments everywhere.
-     * Secondary initialization routine. ONLY CALL ONCE!
-     */
-    void set_cb_info(int (*cb_func)(void *), void *cb_data) noexcept {
-        this->m_cb_func = cb_func;
-        this->m_cb_data = cb_data;
-    }
-
-    /** Get the current user callback function and data. */
-    void get_cb_info(int (**cb_func)(void *), void **cb_data) noexcept {
-        if (cb_func) {
-            *cb_func = m_cb_func;
-        }
-        if (cb_data) {
-            *cb_data = m_cb_data;
-        }
-    }
-
-    /** Arm the callback after construction.
-     *
-     * Calling virtual functions from constructors does not work as expected.
-     * Secondary initialization routine. ONLY CALL ONCE!
-     */
-    virtual int arm() = 0;
-
-    /** Remove the callback before it fires.
-     *
-     * This function should delete the object.
-     */
-    virtual int remove() = 0;
-
-    /** Run the callback.
-     *
-     * This function should delete the object if it can't fire again.
-     */
-    virtual int run() = 0;
-
-  protected:
-    int (*m_cb_func)(void *);  // GPI function to callback
-    void *m_cb_data;           // GPI data supplied to "m_cb_func"
-};
+// Obsolete GPI callback handle
+//
+// This is kept around for now, as PyGPI uses a shared Python object type
+// that is templated on a GPI pointer type,
+// one of which is a pointer to this type.
+class GPI_EXPORT GpiCbHdl {};
 
 class GPI_EXPORT GpiIterator : public GpiHdl {
   public:
@@ -247,22 +262,27 @@ class GPI_EXPORT GpiImplInterface {
                                         gpi_iterator_sel type) = 0;
 
     /* Callback related, these may (will) return the same handle */
-    virtual GpiCbHdl *register_timed_callback(uint64_t time,
-                                              int (*gpi_function)(void *),
-                                              void *gpi_cb_data) = 0;
-    virtual GpiCbHdl *register_readonly_callback(int (*gpi_function)(void *),
-                                                 void *gpi_cb_data) = 0;
-    virtual GpiCbHdl *register_nexttime_callback(int (*gpi_function)(void *),
-                                                 void *gpi_cb_data) = 0;
-    virtual GpiCbHdl *register_readwrite_callback(int (*gpi_function)(void *),
-                                                  void *gpi_cb_data) = 0;
+    virtual gpi_hdl register_timed_callback(uint64_t time,
+                                            int (*gpi_function)(void *),
+                                            void *gpi_cb_data) = 0;
+    virtual gpi_hdl register_readonly_callback(int (*gpi_function)(void *),
+                                               void *gpi_cb_data) = 0;
+    virtual gpi_hdl register_nexttime_callback(int (*gpi_function)(void *),
+                                               void *gpi_cb_data) = 0;
+    virtual gpi_hdl register_readwrite_callback(int (*gpi_function)(void *),
+                                                void *gpi_cb_data) = 0;
+    virtual int remove_callback(gpi_callback *cb) = 0;
 
   private:
     std::string m_name;
 };
 
-/* Called from implementation layers back up the stack */
-GPI_EXPORT int gpi_register_impl(GpiImplInterface *func_tbl);
+/** Register a GPI implementation.
+ *
+ * @param new_impl  Implementation to register.
+ * @return          0 on success, -1 on failure.
+ */
+GPI_EXPORT int gpi_register_impl(GpiImplInterface *new_impl);
 
 // GpiImpls are currently expected to register single callbacks with the
 // interface for the start and end of simulation time. These functions are
@@ -270,26 +290,77 @@ GPI_EXPORT int gpi_register_impl(GpiImplInterface *func_tbl);
 GPI_EXPORT void gpi_start_of_sim_time();
 GPI_EXPORT void gpi_end_of_sim_time();
 
+/** Acquire callback from the object pool, allocating if necessary.
+ *
+ * @return A callback object that is marked as valid.
+ */
+GPI_EXPORT gpi_callback *gpi_callback_acquire();
+
+/** Release a callback to the object pool.
+ *
+ * The released callback will have its metadata updated
+ * to be a different generation and be marked as invalid.
+ *
+ * @param cb Callback object to be released.
+ */
+GPI_EXPORT void gpi_callback_release(gpi_callback *cb);
+
+/** Get a stable pointer from the index in the object pool.
+ *
+ * @param index  Index in the object pool.
+ * @return       Stable callback pointer if index is in the pool, `NULL`
+ *               otherwise.
+ */
+GPI_EXPORT gpi_callback *gpi_callback_from_index(int32_t index);
+
+/** Cleanup value change callbacks.
+ * This should be called before returning from each simulation callback.
+ */
+GPI_EXPORT void gpi_cleanup_valuechange_cbs();
+
+/** Mark value change callback for cleanup. */
+GPI_EXPORT void gpi_mark_valuechange_for_cleanup(gpi_callback *cb);
+
+/** Audit callback pool to check for acquired and not released callbacks. */
+void gpi_callback_audit();
+
+/** Common GPI entry point, called from first implementation after it registers
+ * itself. */
 GPI_EXPORT void gpi_entry_point();
+
+/** Check for cleanup and finalize before returning to simulator. */
 GPI_EXPORT void gpi_check_cleanup();
+
+/** Init GPI logging and debug */
 GPI_EXPORT void gpi_init_logging_and_debug();
 
+/** Shared library support - open library */
 void *utils_dyn_open(const char *lib_name);
+
+/** Shared library support - get exported symbol */
 void *utils_dyn_sym(void *handle, const char *sym_name);
 
-#define GPI_TO_USER_CB(impl) LOG_TRACE("[ " xstr(impl) " ] => User Callback")
+/** Common handler for value change callbacks */
+GPI_EXPORT int32_t handle_value_change_callback(gpi_callback *parent_cb);
 
-#define USER_CB_TO_GPI(impl) LOG_TRACE("User Callback => [ " xstr(impl) " ]")
+/* Trace log helpers */
 
-#define SIM_TO_GPI(impl, cb_reason) \
-    LOG_TRACE("Sim => [ " xstr(impl) " for %s ]", cb_reason)
+#define GPI_TO_USER_CB(impl_str) \
+    LOG_TRACE("[ %s ] => User Callback", (const char *)impl_str)
 
-#define GPI_TO_SIM(impl)                        \
-    do {                                        \
-        gpi_check_cleanup();                    \
-        LOG_TRACE("[ " xstr(impl) " ] => Sim"); \
+#define USER_CB_TO_GPI(impl_str) \
+    LOG_TRACE("User Callback => [ %s ]", (const char *)impl_str)
+
+#define SIM_TO_GPI(impl_str, cb_reason) \
+    LOG_TRACE("Sim => [ %s for %s ]", (const char *)impl_str, cb_reason)
+
+#define GPI_TO_SIM(impl_str)                                \
+    do {                                                    \
+        gpi_check_cleanup();                                \
+        LOG_TRACE("[ %s ] => Sim", (const char *)impl_str); \
     } while (0)
 
+/* Implementation entry points for use with GPI_EXTRA */
 typedef void (*layer_entry_func)();
 
 /* Use this macro in an implementation layer to define an entry point */

--- a/src/cocotb/share/lib/gpi/vhpi/VhpiCbHdl.cpp
+++ b/src/cocotb/share/lib/gpi/vhpi/VhpiCbHdl.cpp
@@ -10,195 +10,388 @@
 #include "_vendor/vhpi/vhpi_user.h"
 #include "gpi.h"
 
+static inline int32_t reason_from_cb_kind(cb_kind kind) {
+    switch (kind & CB_BASIC_KIND) {
+        case CB_READWRITE:
+            return vhpiCbRepLastKnownDeltaCycle;
+        case CB_READONLY:
+            return vhpiCbRepEndOfTimeStep;
+        case CB_NEXT_TIMESTEP:
+            return vhpiCbRepNextTimeStep;
+        case CB_TIMED:
+            return vhpiCbAfterDelay;
+        case CB_VALUE_CHANGE:
+            return vhpiCbValueChange;
+        case CB_STARTUP:
+            return vhpiCbStartOfSimulation;
+        case CB_SHUTDOWN:
+            return vhpiCbEndOfSimulation;
+    }
+    return vhpiCbPLIError;
+}
+
 // Main entry point for callbacks from simulator
-void handle_vhpi_callback(const vhpiCbDataT *cb_data) {
-    SIM_TO_GPI(VHPI, VhpiImpl::reason_to_string(cb_data->reason));
+void handle_vhpi_callback(const vhpiCbDataT *sim_cb_data) {
+    SIM_TO_GPI("VHPI", VhpiImpl::reason_to_string(sim_cb_data->reason));
 
-    VhpiCbHdl *cb_hdl = (VhpiCbHdl *)cb_data->user_data;
+    gpi_callback *cb = (gpi_callback *)sim_cb_data->user_data;
 
-    int error = (!cb_hdl);
+    int32_t error = (!cb);
     // LCOV_EXCL_START
     if (error) {
         LOG_CRITICAL("VHPI: Callback data corrupted: ABORTING");
     }
     // LCOV_EXCL_STOP
 
+    bool valid_cb = false;
     if (!error) {
-        GPI_TO_USER_CB(VHPI);
-        error = cb_hdl->run();
-        USER_CB_TO_GPI(VHPI);
+        valid_cb = cb->meta & META_VALID;
+
+        // LCOV_EXCL_START
+        if (!valid_cb) {
+            LOG_CRITICAL("VHPI: Callback index %d not marked valid: ABORTING",
+                         cb->index);
+            error = 1;
+        }
+        // LCOV_EXCL_STOP
     }
+
+    if (valid_cb) {
+        if (!cb->removed) {
+            if ((cb->kind & CB_BASIC_KIND) == CB_VALUE_CHANGE) {
+                error = handle_value_change_callback(cb);
+            } else {
+                if (cb->user_cb_func) {
+                    GPI_TO_USER_CB("VHPI");
+                    error = cb->user_cb_func(cb->user_cb_data);
+                    USER_CB_TO_GPI("VHPI");
+                } else {
+                    LOG_WARN("VHPI: %s callback has no user callback function",
+                             cb_kind_to_string(cb->kind));
+                }
+            }
+        } else {
+            LOG_TRACE("VHPI: %s callback index %d is removed",
+                      cb_kind_to_string(cb->kind), cb->index);
+        }
+
+        switch (cb->kind & CB_BASIC_KIND) {
+            case CB_READWRITE:
+            case CB_READONLY:
+            case CB_NEXT_TIMESTEP: {
+                if (!cb->removed) {
+                    // For recurring VHPI callbacks, we try to remove them after
+                    // they fire.
+                    vhpiHandleT sim_cb_hdl =
+                        static_cast<vhpiHandleT>(cb->sim_cb_hdl);
+                    int remove_error = vhpi_remove_cb(sim_cb_hdl);
+
+                    // LCOV_EXCL_START
+                    if (remove_error) {
+                        LOG_DEBUG(
+                            "VHPI: Unable to remove %s callback index %d!",
+                            cb_kind_to_string(cb->kind), cb->index);
+                        check_vhpi_error();
+
+                        // If we fail to remove the callback,
+                        // mark as removed so we can ignore next time it fires.
+                        cb->removed = true;
+                    }
+                    // LCOV_EXCL_STOP
+                    else {
+                        gpi_callback_release(cb);
+                    }
+                } else {
+                    // If it has already been removed,
+                    // just release the callback.
+                    gpi_callback_release(cb);
+                }
+                break;
+            }
+            case CB_TIMED:
+            case CB_STARTUP:
+            case CB_SHUTDOWN:
+                // These one-shot callbacks have fired and can be released.
+                gpi_callback_release(cb);
+                break;
+            case CB_VALUE_CHANGE:
+                // If the parent callback object was marked removed,
+                // it should be ignored as if it didn't happen.
+                // The callback has occurred so we can release the handle.
+                if (cb->removed) {
+                    gpi_callback_release(cb);
+                }
+                break;
+        }
+    }
+
+    gpi_cleanup_valuechange_cbs();
 
     if (error) {
         gpi_end_of_sim_time();
     }
 
-    GPI_TO_SIM(VHPI);
+    GPI_TO_SIM("VHPI");
 }
 
-VhpiCbHdl::VhpiCbHdl(GpiImplInterface *impl) : GpiCbHdl(impl) {
-    cb_data.reason = 0;
-    cb_data.cb_rtn = handle_vhpi_callback;
-    cb_data.obj = NULL;
-    cb_data.time = NULL;
-    cb_data.value = NULL;
-    cb_data.user_data = (char *)this;
+gpi_hdl VhpiSignalObjHdl::register_value_change_callback(gpi_edge edge,
+                                                         int (*cb_func)(void *),
+                                                         void *cb_data) {
+    gpi_hdl ret_hdl = gpi_nil_hdl;
 
-    vhpi_time.high = 0;
-    vhpi_time.low = 0;
-}
+    gpi_callback *user_cb = gpi_callback_acquire();
 
-int VhpiCbHdl::remove() {
-    auto err = vhpi_remove_cb(get_handle<vhpiHandleT>());
+    bool valid_cb = true;
+    if (m_valuechange_cb) {
+        // If there is already a sim callback,
+        // add a user callback to the end of the list.
+        user_cb->impl = m_impl;
+        user_cb->parent = m_valuechange_cb;
+        user_cb->user_cb_func = cb_func;
+        user_cb->user_cb_data = cb_data;
+        user_cb->edge = edge;
+        user_cb->kind = CB_VALUE_CHANGE;
+
+        // Update parent
+        m_valuechange_cb->last->next = user_cb;
+        user_cb->prev = m_valuechange_cb->last;
+        m_valuechange_cb->last = user_cb;
+
+        LOG_TRACE(
+            "VHPI: new valuechange child callback index %d added to existing "
+            "parent callback index %d",
+            user_cb->index, m_valuechange_cb->index);
+    } else {
+        // If there is no sim callback,
+        // register one with a parent callback object and start the user
+        // callback list.
+
+        gpi_callback *parent_cb = gpi_callback_acquire();
+
+        vhpiCbDataT vhpi_cb_data = {};
+        vhpi_cb_data.reason = reason_from_cb_kind(CB_VALUE_CHANGE);
+        vhpi_cb_data.cb_rtn = handle_vhpi_callback;
+        vhpi_cb_data.obj = get_handle<vhpiHandleT>();
+        vhpi_cb_data.user_data = (char *)parent_cb;
+
+        vhpiHandleT sim_cb_hdl = vhpi_register_cb(&vhpi_cb_data, vhpiReturnCb);
+
+        bool valid_sim_cb = true;
+        // LCOV_EXCL_START
+        if (!sim_cb_hdl) {
+            check_vhpi_error();
+            LOG_ERROR(
+                "VHPI: Unable to register a callback handle for VHPI type "
+                "%s(%d)",
+                VhpiImpl::reason_to_string(vhpi_cb_data.reason),
+                vhpi_cb_data.reason);
+            valid_sim_cb = false;
+        }
+        // LCOV_EXCL_STOP
+
+        if (valid_sim_cb) {
+            parent_cb->impl = m_impl;
+            parent_cb->sim_cb_hdl = sim_cb_hdl;
+            parent_cb->next = user_cb;
+            parent_cb->last = user_cb;
+            parent_cb->signal = this;
+            parent_cb->kind = CB_VALUE_CHANGE | CB_PARENT;
+
+            user_cb->impl = m_impl;
+            user_cb->parent = parent_cb;
+            user_cb->prev = parent_cb;
+            user_cb->user_cb_func = cb_func;
+            user_cb->user_cb_data = cb_data;
+            user_cb->edge = edge;
+            user_cb->kind = CB_VALUE_CHANGE;
+
+            m_valuechange_cb = parent_cb;
+
+            LOG_TRACE(
+                "VPI: from sim callback %p -> new valuechange parent callback "
+                "index %d and child callback index %d",
+                sim_cb_hdl, parent_cb->index, user_cb->index);
+        }
+        // LCOV_EXCL_START
+        else {
+            gpi_callback_release(parent_cb);
+            valid_cb = false;
+        }
+        // LCOV_EXCL_STOP
+    }
+
+    if (valid_cb) {
+        ret_hdl.index = user_cb->index;
+        ret_hdl.meta = user_cb->meta;
+    }
     // LCOV_EXCL_START
-    if (err) {
-        LOG_DEBUG("VHPI: Unable to remove callback!");
-        check_vhpi_error();
-        // If we fail to remove the callback, mark it as removed so once it
-        // fires we can squash it then remove the callback cleanly.
-        m_removed = true;
+    else {
+        gpi_callback_release(user_cb);
     }
     // LCOV_EXCL_STOP
-    else {
-        delete this;
-    }
-    return 0;
+
+    return ret_hdl;
 }
 
-int VhpiCbHdl::arm() {
-    vhpiHandleT new_hdl = vhpi_register_cb(&cb_data, vhpiReturnCb);
+gpi_hdl VhpiImpl::register_non_valuechange_callback(cb_kind kind, uint64_t time,
+                                                    int (*cb_func)(void *),
+                                                    void *cb_data) {
+    gpi_hdl ret_hdl = gpi_nil_hdl;
 
+    gpi_callback *cb = gpi_callback_acquire();
+
+    vhpiTimeT vhpi_time = {};
+    vhpi_time.high = (uint32_t)(time >> 32);
+    vhpi_time.low = (uint32_t)(time);
+
+    vhpiCbDataT vhpi_cb_data = {};
+    vhpi_cb_data.reason = reason_from_cb_kind(kind);
+    vhpi_cb_data.cb_rtn = handle_vhpi_callback;
+    // For non vhpiCbAfterDelay callbacks,
+    // providing a non-NULL time member will result in
+    // the callback data having a time value of when event occurred,
+    // so it's fine.
+    // (IEEE Std 1076-2008 21.3.2.1)
+    vhpi_cb_data.time = &vhpi_time;
+    vhpi_cb_data.user_data = (char *)cb;
+
+    vhpiHandleT sim_cb_hdl = vhpi_register_cb(&vhpi_cb_data, vhpiReturnCb);
+
+    bool valid_cb = true;
     // LCOV_EXCL_START
-    if (!new_hdl) {
+    if (!sim_cb_hdl) {
         check_vhpi_error();
         LOG_ERROR(
             "VHPI: Unable to register a callback handle for VHPI type "
             "%s(%d)",
-            VhpiImpl::reason_to_string(cb_data.reason), cb_data.reason);
-        check_vhpi_error();
-        return -1;
+            reason_to_string(vhpi_cb_data.reason), vhpi_cb_data.reason);
+        valid_cb = false;
     }
     // LCOV_EXCL_STOP
 
-    m_obj_hdl = new_hdl;
-    return 0;
-}
+    if (valid_cb) {
+        cb->impl = this;
+        cb->sim_cb_hdl = sim_cb_hdl;
+        cb->user_cb_func = cb_func;
+        cb->user_cb_data = cb_data;
+        cb->kind = kind;
 
-int VhpiCbHdl::run() {
-    int res = 0;
-
+        ret_hdl.index = cb->index;
+        ret_hdl.meta = cb->meta;
+    }
     // LCOV_EXCL_START
-    if (!m_removed) {
-        // Only call up if not removed.
-        res = m_cb_func(m_cb_data);
-    }
-    // LCOV_EXCL_STOP
-
-    // Many callbacks in VHPI are recurring, so we try to remove them after they
-    // fire. For the callbacks that aren't recurring, this doesn't seem to make
-    // the simulator unhappy, so whatever.
-    auto err = vhpi_remove_cb(get_handle<vhpiHandleT>());
-    // LCOV_EXCL_START
-    if (err) {
-        LOG_DEBUG("VHPI: Unable to remove callback!");
-        check_vhpi_error();
-        // If we fail to remove the callback, mark it as removed so if it fires
-        // we can squash it.
-        m_removed = true;
-    }
-    // LCOV_EXCL_STOP
     else {
-        delete this;
+        gpi_callback_release(cb);
     }
-    return res;
+    // LCOV_EXCL_STOP
+
+    return ret_hdl;
 }
 
-VhpiValueCbHdl::VhpiValueCbHdl(GpiImplInterface *impl, VhpiSignalObjHdl *sig,
-                               gpi_edge edge)
-    : VhpiCbHdl(impl), m_signal(sig), m_edge(edge) {
-    cb_data.reason = vhpiCbValueChange;
-    cb_data.time = &vhpi_time;
-    cb_data.obj = m_signal->get_handle<vhpiHandleT>();
+gpi_hdl VhpiImpl::register_timed_callback(uint64_t time, int (*cb_func)(void *),
+                                          void *cb_data) {
+    return register_non_valuechange_callback(CB_TIMED, time, cb_func, cb_data);
 }
 
-int VhpiValueCbHdl::run() {
-    // LCOV_EXCL_START
-    if (m_removed) {
-        // Only call up if not removed.
+gpi_hdl VhpiImpl::register_readonly_callback(int (*cb_func)(void *),
+                                             void *cb_data) {
+    return register_non_valuechange_callback(CB_READONLY, 0, cb_func, cb_data);
+}
+
+gpi_hdl VhpiImpl::register_readwrite_callback(int (*cb_func)(void *),
+                                              void *cb_data) {
+    return register_non_valuechange_callback(CB_READWRITE, 0, cb_func, cb_data);
+}
+
+gpi_hdl VhpiImpl::register_nexttime_callback(int (*cb_func)(void *),
+                                             void *cb_data) {
+    return register_non_valuechange_callback(CB_NEXT_TIMESTEP, 0, cb_func,
+                                             cb_data);
+}
+
+int VhpiImpl::remove_callback(gpi_callback *cb) {
+    if (cb->removed) {
         return 0;
     }
-    // LCOV_EXCL_STOP
 
-    bool pass = false;
-    switch (m_edge) {
-        case GPI_RISING: {
-            pass = !strcmp(m_signal->get_signal_value_binstr(), "1");
+    // Mark as removed
+    cb->removed = true;
+
+    switch (cb->kind & CB_BASIC_KIND) {
+        case CB_READWRITE:
+        case CB_READONLY:
+        case CB_NEXT_TIMESTEP:
+        case CB_TIMED: {
+            vhpiHandleT sim_cb_hdl = static_cast<vhpiHandleT>(cb->sim_cb_hdl);
+            int remove_error = vhpi_remove_cb(sim_cb_hdl);
+
+            // LCOV_EXCL_START
+            if (remove_error) {
+                LOG_DEBUG("VHPI: Unable to remove %s callback index %d!",
+                          cb_kind_to_string(cb->kind), cb->index);
+                check_vhpi_error();
+
+                // It is already marked removed but we don't release it until
+                // the callback fires
+            }
+            // LCOV_EXCL_STOP
+            else {
+                gpi_callback_release(cb);
+            }
             break;
         }
-        case GPI_FALLING: {
-            pass = !strcmp(m_signal->get_signal_value_binstr(), "0");
+        case CB_STARTUP:
+        case CB_SHUTDOWN: {
+            // Too many sims get upset trying to remove startup callbacks so we
+            // just don't try
             break;
         }
-        case GPI_VALUE_CHANGE: {
-            pass = true;
+        case CB_VALUE_CHANGE: {
+            // There are two types of value change callbacks to remove.
+            // 1. User callbacks that are children of a parent callback
+            // 2. Parent callbacks that are associated with the simulator
+            // callback
+            //
+            // For user callbacks, we mark them for cleanup later,
+            // before the sim callback returns.
+            // In the later cleanup, if all child callbacks have been removed
+            // and marked for cleanup,
+            // this function will get called on the parent callback.
+            // In that case, we try to remove the sim callback
+            // and clear it from the associated signal object.
+
+            if (cb->kind & CB_PARENT) {
+                vhpiHandleT sim_cb_hdl =
+                    static_cast<vhpiHandleT>(cb->sim_cb_hdl);
+                int remove_error = vhpi_remove_cb(sim_cb_hdl);
+
+                // LCOV_EXCL_START
+                if (remove_error) {
+                    LOG_DEBUG(
+                        "VHPI: Unable to remove valuechange callback index %d!",
+                        cb->index);
+                    check_vhpi_error();
+
+                    // It is already marked removed but we don't release it
+                    // until the callback fires
+                }
+                // LCOV_EXCL_STOP
+                else {
+                    gpi_callback_release(cb);
+
+                    cb->signal->m_valuechange_cb = nullptr;
+                }
+            } else {
+                // Don't release it here, just mark it to be cleaned up before
+                // the callback returns
+                gpi_mark_valuechange_for_cleanup(cb);
+            }
             break;
         }
+
+        default:
+            break;
     }
 
-    int res = 0;
-    if (pass) {
-        res = m_cb_func(m_cb_data);
-
-        // Remove recurring callback once fired
-        auto err = vhpi_remove_cb(get_handle<vhpiHandleT>());
-        // LCOV_EXCL_START
-        if (err) {
-            LOG_DEBUG("VHPI: Unable to remove callback!");
-            check_vhpi_error();
-            // If we fail to remove the callback, mark it as removed so if it
-            // fires we can squash it.
-            m_removed = true;
-        }
-        // LCOV_EXCL_STOP
-        else {
-            delete this;
-        }
-
-    }  // else Don't remove and let it fire again.
-
-    return res;
-}
-
-VhpiStartupCbHdl::VhpiStartupCbHdl(GpiImplInterface *impl) : VhpiCbHdl(impl) {
-    cb_data.reason = vhpiCbStartOfSimulation;
-}
-
-VhpiShutdownCbHdl::VhpiShutdownCbHdl(GpiImplInterface *impl) : VhpiCbHdl(impl) {
-    cb_data.reason = vhpiCbEndOfSimulation;
-}
-
-VhpiTimedCbHdl::VhpiTimedCbHdl(GpiImplInterface *impl, uint64_t time)
-    : VhpiCbHdl(impl) {
-    vhpi_time.high = (uint32_t)(time >> 32);
-    vhpi_time.low = (uint32_t)(time);
-
-    cb_data.reason = vhpiCbAfterDelay;
-    cb_data.time = &vhpi_time;
-}
-
-VhpiReadWriteCbHdl::VhpiReadWriteCbHdl(GpiImplInterface *impl)
-    : VhpiCbHdl(impl) {
-    cb_data.reason = vhpiCbRepLastKnownDeltaCycle;
-    cb_data.time = &vhpi_time;
-}
-
-VhpiReadOnlyCbHdl::VhpiReadOnlyCbHdl(GpiImplInterface *impl) : VhpiCbHdl(impl) {
-    cb_data.reason = vhpiCbRepEndOfTimeStep;
-    cb_data.time = &vhpi_time;
-}
-
-VhpiNextPhaseCbHdl::VhpiNextPhaseCbHdl(GpiImplInterface *impl)
-    : VhpiCbHdl(impl) {
-    cb_data.reason = vhpiCbRepNextTimeStep;
-    cb_data.time = &vhpi_time;
+    return 0;
 }

--- a/src/cocotb/share/lib/gpi/vhpi/VhpiImpl.cpp
+++ b/src/cocotb/share/lib/gpi/vhpi/VhpiImpl.cpp
@@ -1002,69 +1002,8 @@ GpiIterator *VhpiImpl::iterate_handle(GpiObjHdl *obj_hdl,
     return new_iter;
 }
 
-GpiCbHdl *VhpiImpl::register_timed_callback(uint64_t time,
-                                            int (*cb_func)(void *),
-                                            void *cb_data) {
-    auto *cb_hdl = new VhpiTimedCbHdl(this, time);
-
-    auto err = cb_hdl->arm();
-    // LCOV_EXCL_START
-    if (err) {
-        delete cb_hdl;
-        return NULL;
-    }
-    // LCOV_EXCL_STOP
-    cb_hdl->set_cb_info(cb_func, cb_data);
-    return cb_hdl;
-}
-
-GpiCbHdl *VhpiImpl::register_readwrite_callback(int (*cb_func)(void *),
-                                                void *cb_data) {
-    auto *cb_hdl = new VhpiReadWriteCbHdl(this);
-
-    auto err = cb_hdl->arm();
-    // LCOV_EXCL_START
-    if (err) {
-        delete cb_hdl;
-        return NULL;
-    }
-    // LCOV_EXCL_STOP
-    cb_hdl->set_cb_info(cb_func, cb_data);
-    return cb_hdl;
-}
-
-GpiCbHdl *VhpiImpl::register_readonly_callback(int (*cb_func)(void *),
-                                               void *cb_data) {
-    auto *cb_hdl = new VhpiReadOnlyCbHdl(this);
-
-    auto err = cb_hdl->arm();
-    // LCOV_EXCL_START
-    if (err) {
-        delete cb_hdl;
-        return NULL;
-    }
-    // LCOV_EXCL_STOP
-    cb_hdl->set_cb_info(cb_func, cb_data);
-    return cb_hdl;
-}
-
-GpiCbHdl *VhpiImpl::register_nexttime_callback(int (*cb_func)(void *),
-                                               void *cb_data) {
-    auto *cb_hdl = new VhpiNextPhaseCbHdl(this);
-
-    auto err = cb_hdl->arm();
-    // LCOV_EXCL_START
-    if (err) {
-        delete cb_hdl;
-        return NULL;
-    }
-    // LCOV_EXCL_STOP
-    cb_hdl->set_cb_info(cb_func, cb_data);
-    return cb_hdl;
-}
-
 void VhpiImpl::sim_end() {
-    m_sim_finish_cb->remove();
+    remove_callback(m_sim_finish_cb);
     int err = vhpi_control(vhpiFinish, vhpiDiagTimeLoc);
     // LCOV_EXCL_START
     if (err) {
@@ -1097,33 +1036,34 @@ static int shutdown_callback(void *) {
 }
 
 void VhpiImpl::main() noexcept {
-    auto startup_cb = new VhpiStartupCbHdl(this);
-    auto err = startup_cb->arm();
+    gpi_hdl startup_hdl = register_non_valuechange_callback(
+        CB_STARTUP, 0, startup_callback, nullptr);
+
     // LCOV_EXCL_START
-    if (err) {
+    if (!(startup_hdl.meta & META_VALID)) {
         LOG_CRITICAL(
             "VHPI: Unable to register startup callback! Simulation will end.");
         check_vhpi_error();
-        delete startup_cb;
         exit(1);
     }
     // LCOV_EXCL_STOP
-    startup_cb->set_cb_info(startup_callback, nullptr);
 
-    auto shutdown_cb = new VhpiShutdownCbHdl(this);
-    err = shutdown_cb->arm();
+    gpi_callback *startup_cb = gpi_callback_from_index(startup_hdl.index);
+
+    gpi_hdl shutdown_hdl = register_non_valuechange_callback(
+        CB_SHUTDOWN, 0, shutdown_callback, nullptr);
+
     // LCOV_EXCL_START
-    if (err) {
+    if (!(shutdown_hdl.meta & META_VALID)) {
         LOG_CRITICAL(
             "VHPI: Unable to register shutdown callback! Simulation will end.");
         check_vhpi_error();
-        startup_cb->remove();
-        delete shutdown_cb;
+        remove_callback(startup_cb);
         exit(1);
     }
     // LCOV_EXCL_STOP
-    shutdown_cb->set_cb_info(shutdown_callback, nullptr);
-    m_sim_finish_cb = shutdown_cb;
+
+    m_sim_finish_cb = gpi_callback_from_index(shutdown_hdl.index);
 
     gpi_register_impl(this);
     gpi_entry_point();

--- a/src/cocotb/share/lib/gpi/vhpi/VhpiImpl.hpp
+++ b/src/cocotb/share/lib/gpi/vhpi/VhpiImpl.hpp
@@ -80,101 +80,6 @@ static inline void __check_vhpi_error(const char *file, const char *func,
         __check_vhpi_error(__FILE__, __func__, __LINE__); \
     } while (0)
 
-class VhpiCbHdl : public GpiCbHdl {
-  public:
-    VhpiCbHdl(GpiImplInterface *impl);
-
-    int arm() override;
-    int remove() override;
-    int run() override;
-
-  protected:
-    vhpiCbDataT cb_data;
-    vhpiTimeT vhpi_time;
-    bool m_removed = false;
-};
-
-class VhpiSignalObjHdl;
-
-class VhpiValueCbHdl : public VhpiCbHdl {
-  public:
-    VhpiValueCbHdl(GpiImplInterface *impl, VhpiSignalObjHdl *sig,
-                   gpi_edge edge);
-    int run() override;
-
-  private:
-    GpiSignalObjHdl *m_signal;
-    gpi_edge m_edge;
-};
-
-class VhpiTimedCbHdl : public VhpiCbHdl {
-  public:
-    VhpiTimedCbHdl(GpiImplInterface *impl, uint64_t time);
-};
-
-class VhpiReadOnlyCbHdl : public VhpiCbHdl {
-  public:
-    VhpiReadOnlyCbHdl(GpiImplInterface *impl);
-};
-
-class VhpiNextPhaseCbHdl : public VhpiCbHdl {
-  public:
-    VhpiNextPhaseCbHdl(GpiImplInterface *impl);
-};
-
-class VhpiStartupCbHdl : public VhpiCbHdl {
-  public:
-    VhpiStartupCbHdl(GpiImplInterface *impl);
-
-    // Too many sims get upset trying to remove startup callbacks so we just
-    // don't try. TODO Is this still accurate?
-
-    int run() override {
-        int res = 0;
-        if (!m_removed) {
-            res = m_cb_func(m_cb_data);
-        } else {
-            LOG_TRACE("[ VHPI (startup) ] callback is removed");
-        }
-        delete this;
-        return res;
-    }
-
-    int remove() override {
-        m_removed = true;
-        return 0;
-    }
-};
-
-class VhpiShutdownCbHdl : public VhpiCbHdl {
-  public:
-    VhpiShutdownCbHdl(GpiImplInterface *impl);
-
-    // Too many sims get upset trying to remove startup callbacks so we just
-    // don't try. TODO Is this still accurate?
-
-    int run() override {
-        int res = 0;
-        if (!m_removed) {
-            res = m_cb_func(m_cb_data);
-        } else {
-            LOG_TRACE("[ VHPI (shutdown) ] callback is removed");
-        }
-        delete this;
-        return res;
-    }
-
-    int remove() override {
-        m_removed = true;
-        return 0;
-    }
-};
-
-class VhpiReadWriteCbHdl : public VhpiCbHdl {
-  public:
-    VhpiReadWriteCbHdl(GpiImplInterface *impl);
-};
-
 class VhpiArrayObjHdl : public GpiObjHdl {
   public:
     VhpiArrayObjHdl(GpiImplInterface *impl, vhpiHandleT hdl,
@@ -218,12 +123,11 @@ class VhpiSignalObjHdl : public GpiSignalObjHdl {
     int set_signal_value_binstr(std::string &value,
                                 gpi_set_action action) override;
 
-    /* Value change callback accessor */
     int initialise(const std::string &name,
                    const std::string &fq_name) override;
-    GpiCbHdl *register_value_change_callback(gpi_edge edge,
-                                             int (*function)(void *),
-                                             void *cb_data) override;
+    gpi_hdl register_value_change_callback(gpi_edge edge,
+                                           int (*function)(void *),
+                                           void *cb_data) override;
 
   protected:
     vhpiEnumT chr2vhpi(char value);
@@ -281,15 +185,23 @@ class VhpiImpl : public GpiImplInterface {
     GpiIterator *iterate_handle(GpiObjHdl *obj_hdl,
                                 gpi_iterator_sel type) override;
 
-    /* Callback related, these may (will) return the same handle*/
-    GpiCbHdl *register_timed_callback(uint64_t time, int (*function)(void *),
-                                      void *cb_data) override;
-    GpiCbHdl *register_readonly_callback(int (*function)(void *),
-                                         void *cb_data) override;
-    GpiCbHdl *register_nexttime_callback(int (*function)(void *),
-                                         void *cb_data) override;
-    GpiCbHdl *register_readwrite_callback(int (*function)(void *),
-                                          void *cb_data) override;
+    /* Callback related */
+
+    // Helper function to hold common functionality
+    gpi_hdl register_non_valuechange_callback(cb_kind kind, uint64_t time,
+                                              int (*cb_func)(void *),
+                                              void *cb_data);
+
+    gpi_hdl register_timed_callback(uint64_t time, int (*function)(void *),
+                                    void *cb_data) override;
+    gpi_hdl register_readonly_callback(int (*function)(void *),
+                                       void *cb_data) override;
+    gpi_hdl register_nexttime_callback(int (*function)(void *),
+                                       void *cb_data) override;
+    gpi_hdl register_readwrite_callback(int (*function)(void *),
+                                        void *cb_data) override;
+    int remove_callback(gpi_callback *cb) override;
+
     GpiObjHdl *get_child_by_name(const std::string &name,
                                  GpiObjHdl *parent) override;
     GpiObjHdl *get_child_by_index(int32_t index, GpiObjHdl *parent) override;
@@ -314,9 +226,10 @@ class VhpiImpl : public GpiImplInterface {
     void main() noexcept;
 
   private:
-    // We store the shutdown callback handle here so sim_end() can remove() it
-    // if it's called.
-    VhpiShutdownCbHdl *m_sim_finish_cb;
+    // We store the shutdown callback handle here so that if sim_end() is
+    // called, it can be removed.
+    gpi_callback *m_sim_finish_cb;
+
     std::string m_product;
     std::string m_version;
     int m_argc = 0;

--- a/src/cocotb/share/lib/gpi/vhpi/VhpiSignal.cpp
+++ b/src/cocotb/share/lib/gpi/vhpi/VhpiSignal.cpp
@@ -538,20 +538,6 @@ long VhpiSignalObjHdl::get_signal_value_long() {
     return static_cast<int32_t>(value.value.intg);
 }
 
-GpiCbHdl *VhpiSignalObjHdl::register_value_change_callback(
-    gpi_edge edge, int (*cb_func)(void *), void *cb_data) {
-    auto cb_hdl = new VhpiValueCbHdl(m_impl, this, edge);
-    auto err = cb_hdl->arm();
-    // LCOV_EXCL_START
-    if (err) {
-        delete cb_hdl;
-        return NULL;
-    }
-    // LCOV_EXCL_STOP
-    cb_hdl->set_cb_info(cb_func, cb_data);
-    return cb_hdl;
-}
-
 int VhpiSignalObjHdl::get_signed() {
     if (m_type == GPI_INTEGER) {
         return 1;

--- a/src/cocotb/share/lib/gpi/vpi/VpiCbHdl.cpp
+++ b/src/cocotb/share/lib/gpi/vpi/VpiCbHdl.cpp
@@ -12,22 +12,133 @@
 #include <algorithm>
 #include <deque>
 
-static std::deque<VpiCbHdl *> cb_queue;
+static std::deque<gpi_callback *> cb_queue;
 #endif
 
-static int32_t handle_vpi_callback_(VpiCbHdl *cb_hdl) {
-    int error = (!cb_hdl);
+static inline PLI_INT32 reason_from_cb_kind(cb_kind kind) {
+    switch (kind & CB_BASIC_KIND) {
+        case CB_READWRITE:
+            return cbReadWriteSynch;
+        case CB_READONLY:
+            return cbReadOnlySynch;
+        case CB_NEXT_TIMESTEP:
+            return cbNextSimTime;
+        case CB_TIMED:
+            return cbAfterDelay;
+        case CB_VALUE_CHANGE:
+            return cbValueChange;
+
+        case CB_STARTUP:
+#ifdef IUS
+            return cbAfterDelay;
+#else
+            return cbStartOfSimulation;
+#endif
+        case CB_SHUTDOWN:
+            return cbEndOfSimulation;
+    }
+    return cbPLIError;
+}
+
+static int32_t handle_vpi_callback_(gpi_callback *cb) {
+    int32_t error = (!cb);
     // LCOV_EXCL_START
     if (error) {
         LOG_CRITICAL("VPI: Callback data corrupted: ABORTING");
     }
     // LCOV_EXCL_STOP
 
+    bool valid_cb = false;
     if (!error) {
-        GPI_TO_USER_CB(VPI);
-        error = cb_hdl->run();
-        USER_CB_TO_GPI(VPI);
+        valid_cb = cb->meta & META_VALID;
+
+        // LCOV_EXCL_START
+        if (!valid_cb) {
+            LOG_CRITICAL("VPI: Callback index %d not marked valid: ABORTING",
+                         cb->index);
+            error = 1;
+        }
+        // LCOV_EXCL_STOP
     }
+
+    if (valid_cb) {
+        if (!cb->removed) {
+            if ((cb->kind & CB_BASIC_KIND) == CB_VALUE_CHANGE) {
+                error = handle_value_change_callback(cb);
+            } else {
+                if (cb->user_cb_func) {
+                    GPI_TO_USER_CB("VPI");
+                    error = cb->user_cb_func(cb->user_cb_data);
+                    USER_CB_TO_GPI("VPI");
+                } else {
+                    LOG_WARN("VPI: %s callback has no user callback function",
+                             cb_kind_to_string(cb->kind));
+                }
+            }
+        } else {
+            LOG_TRACE("VPI: %s callback index %d is removed",
+                      cb_kind_to_string(cb->kind), cb->index);
+        }
+
+        switch (cb->kind & CB_BASIC_KIND) {
+            case CB_READWRITE:
+            case CB_READONLY:
+            case CB_NEXT_TIMESTEP:
+            case CB_TIMED:
+            case CB_STARTUP:
+            case CB_SHUTDOWN:
+#ifdef VERILATOR
+            {
+                if (!cb->removed) {
+                    // Verilator seems to think some callbacks are recurring
+                    // that Icarus and other sims do not. So we remove all
+                    // callbacks here after firing because Verilator doesn't
+                    // seem to mind (other sims do). Remove recurring callback
+                    // once fired
+                    vpiHandle sim_cb_hdl =
+                        static_cast<vpiHandle>(cb->sim_cb_hdl);
+                    int remove_success = vpi_remove_cb(sim_cb_hdl);
+
+                    // LCOV_EXCL_START
+                    if (!remove_success) {
+                        LOG_DEBUG("VPI: Unable to remove %s callback index %d!",
+                                  cb_kind_to_string(cb->kind), cb->index);
+                        check_vpi_error();
+
+                        // If we fail to remove the callback,
+                        // mark as removed so we can ignore next time it fires.
+                        cb->removed = true;
+                    }
+                    // LCOV_EXCL_STOP
+                    else {
+                        // If we removed it successfully,
+                        // release the callback.
+                        gpi_callback_release(cb);
+                    }
+                } else {
+                    // If it has already been removed,
+                    // just release the callback.
+                    gpi_callback_release(cb);
+                }
+                break;
+            }
+#else
+                // These one-shot callbacks have fired and can be released.
+                gpi_callback_release(cb);
+                break;
+#endif
+            case CB_VALUE_CHANGE:
+                // If the parent callback object was marked removed,
+                // it should be ignored as if it didn't happen.
+                // The callback has occurred so we can release the handle.
+                if (cb->removed) {
+                    gpi_callback_release(cb);
+                }
+                break;
+        }
+    }
+
+    gpi_cleanup_valuechange_cbs();
 
     if (error) {
         gpi_end_of_sim_time();
@@ -37,225 +148,319 @@ static int32_t handle_vpi_callback_(VpiCbHdl *cb_hdl) {
 }
 
 // Main re-entry point for callbacks from simulator
-int32_t handle_vpi_callback(p_cb_data cb_data) {
-    SIM_TO_GPI(VPI, VpiImpl::reason_to_string(cb_data->reason));
+int32_t handle_vpi_callback(p_cb_data sim_cb_data) {
+    SIM_TO_GPI("VPI", VpiImpl::reason_to_string(sim_cb_data->reason));
 
-    int ret = 0;
+    int handle_error = 0;
+    gpi_callback *cb = (gpi_callback *)sim_cb_data->user_data;
 #ifdef VPI_NO_QUEUE_SETIMMEDIATE_CALLBACKS
-    VpiCbHdl *cb_hdl = (VpiCbHdl *)cb_data->user_data;
-    ret = handle_vpi_callback_(cb_hdl);
+    handle_error = handle_vpi_callback_(cb);
 #else
     // must push things into a queue because Icarus (gh-4067), Xcelium
     // (gh-4013), and Questa (gh-4105) react to value changes on signals that
     // are set with vpiNoDelay immediately, and not after the current callback
     // has ended, causing re-entrancy.
     static bool reacting = false;
-    VpiCbHdl *cb_hdl = (VpiCbHdl *)cb_data->user_data;
     if (reacting) {
-        cb_queue.push_back(cb_hdl);
+        cb_queue.push_back(cb);
     } else {
         reacting = true;
-        ret = handle_vpi_callback_(cb_hdl);
+        handle_error = handle_vpi_callback_(cb);
         while (!cb_queue.empty()) {
-            handle_vpi_callback_(cb_queue.front());
-            cb_queue.pop_front();
+            gpi_callback *next_cb = cb_queue.front();
+
+            if (handle_error) {
+                LOG_WARN(
+                    "VPI: There was an error handling previous callback. "
+                    "Skipping handling of %s callback index %d",
+                    cb_kind_to_string(cb->kind), cb->index);
+            } else {
+                handle_error = handle_vpi_callback_(next_cb);
+            }
+
+            // The processed callback may have already been removed while it was
+            // executing, so search for it and don't just pop the front.
+            auto it = std::find(cb_queue.begin(), cb_queue.end(), next_cb);
+            if (it != cb_queue.end()) {
+                cb_queue.erase(it);
+            }
         }
         reacting = false;
     }
 #endif
-    GPI_TO_SIM(VPI);
-    return ret;
+    GPI_TO_SIM("VPI");
+    return handle_error;
 }
 
-VpiCbHdl::VpiCbHdl(GpiImplInterface *impl) : GpiCbHdl(impl) {
-    vpi_time.high = 0;
-    vpi_time.low = 0;
-    vpi_time.type = vpiSimTime;
+gpi_hdl VpiImpl::register_non_valuechange_callback(cb_kind kind, uint64_t time,
+                                                   int (*cb_func)(void *),
+                                                   void *cb_data) {
+    gpi_hdl ret_hdl = gpi_nil_hdl;
 
-    cb_data.reason = 0;
-    cb_data.cb_rtn = handle_vpi_callback;
-    cb_data.obj = NULL;
-    cb_data.time = &vpi_time;
-    cb_data.value = NULL;
-    cb_data.index = 0;
-    cb_data.user_data = (char *)this;
-}
+    gpi_callback *cb = gpi_callback_acquire();
 
-int VpiCbHdl::arm() {
-    vpiHandle new_hdl = vpi_register_cb(&cb_data);
-
-    if (!new_hdl) {
-        LOG_ERROR(
-            "VPI: Unable to register a callback handle for VPI type %s(%d)",
-            VpiImpl::reason_to_string(cb_data.reason), cb_data.reason);
-        check_vpi_error();
-        return -1;
-    }
-
-    m_obj_hdl = new_hdl;
-
-    return 0;
-}
-
-int VpiCbHdl::remove() {
-#ifndef VPI_NO_QUEUE_SETIMMEDIATE_CALLBACKS
-    // check if it's already fired and is in callback queue
-    auto it = std::find(cb_queue.begin(), cb_queue.end(), this);
-    if (it != cb_queue.end()) {
-        cb_queue.erase(it);
-        // In Verilator some callbacks are recurring, so we *should* try to
-        // remove by falling through to the code below. Other sims don't like
-        // removing callbacks that have already fired.
-#ifndef VERILATOR
-        // It's already fired, we shouldn't try to vpi_remove_cb() it now.
-        delete this;
-        return 0;
-#endif
-    }
-#endif
-
-    auto err = vpi_remove_cb(get_handle<vpiHandle>());
-    // LCOV_EXCL_START
-    if (!err) {
-        LOG_DEBUG("VPI: Unable to remove callback");
-        check_vpi_error();
-        // put it in a removed state so if it fires we can squash it
-        m_removed = true;
-    }
-    // LCOV_EXCL_STOP
-    else {
-        delete this;
-    }
-    return 0;
-}
-
-int VpiCbHdl::run() {
-    int res = 0;
-
-    // LCOV_EXCL_START
-    if (!m_removed) {
-        // Only call up if not removed.
-        res = m_cb_func(m_cb_data);
-    }
-    // LCOV_EXCL_STOP
-
-// Verilator seems to think some callbacks are recurring that Icarus and other
-// sims do not. So we remove all callbacks here after firing because Verilator
-// doesn't seem to mind (other sims do).
-#ifdef VERILATOR
-    // Remove recurring callback once fired
-    auto err = vpi_remove_cb(get_handle<vpiHandle>());
-    // LCOV_EXCL_START
-    if (!err) {
-        LOG_DEBUG("VPI: Unable to remove callback");
-        check_vpi_error();
-        // put it in a removed state so if it fires we can squash it
-        m_removed = true;
-    }
-    // LCOV_EXCL_STOP
-    else {
-        delete this;
-    }
-#else
-    // For other simulators: VPI spec says one-shot callbacks auto-cleanup
-    // their handle after firing. We just need to delete the C++ object.
-    delete this;
-#endif
-
-    return res;
-}
-
-VpiValueCbHdl::VpiValueCbHdl(GpiImplInterface *impl, VpiSignalObjHdl *signal,
-                             gpi_edge edge)
-    : VpiCbHdl(impl), m_signal(signal), m_edge(edge) {
-    vpi_time.type = vpiSuppressTime;
-    m_vpi_value.format = vpiIntVal;
-
-    cb_data.reason = cbValueChange;
-    cb_data.time = &vpi_time;
-    cb_data.value = &m_vpi_value;
-    cb_data.obj = m_signal->get_handle<vpiHandle>();
-}
-
-int VpiValueCbHdl::run() {
-    // LCOV_EXCL_START
-    if (m_removed) {
-        // Only call up if not removed.
-        return 0;
-    }
-    // LCOV_EXCL_STOP
-
-    bool pass = false;
-    switch (m_edge) {
-        case GPI_RISING: {
-            pass = !strcmp(m_signal->get_signal_value_binstr(), "1");
-            break;
-        }
-        case GPI_FALLING: {
-            pass = !strcmp(m_signal->get_signal_value_binstr(), "0");
-            break;
-        }
-        case GPI_VALUE_CHANGE: {
-            pass = true;
-            break;
-        }
-    }
-
-    int res = 0;
-    if (pass) {
-        res = m_cb_func(m_cb_data);
-
-        // Remove recurring callback once fired.
-        auto err = vpi_remove_cb(get_handle<vpiHandle>());
-        // LCOV_EXCL_START
-        if (!err) {
-            LOG_DEBUG("VPI: Unable to remove callback");
-            check_vpi_error();
-            // If we fail to remove the callback, put it in a removed state so
-            // if it fires we can squash it.
-            m_removed = true;
-        }
-        // LCOV_EXCL_STOP
-        else {
-            delete this;
-        }
-    }  // else Don't remove and let it fire again.
-
-    return res;
-}
-
-VpiStartupCbHdl::VpiStartupCbHdl(GpiImplInterface *impl) : VpiCbHdl(impl) {
-#ifndef IUS
-    cb_data.reason = cbStartOfSimulation;
-#else
-    vpi_time.high = (uint32_t)(0);
-    vpi_time.low = (uint32_t)(0);
-    vpi_time.type = vpiSimTime;
-    cb_data.reason = cbAfterDelay;
-#endif
-}
-
-VpiShutdownCbHdl::VpiShutdownCbHdl(GpiImplInterface *impl) : VpiCbHdl(impl) {
-    cb_data.reason = cbEndOfSimulation;
-}
-
-VpiTimedCbHdl::VpiTimedCbHdl(GpiImplInterface *impl, uint64_t time)
-    : VpiCbHdl(impl) {
+    s_vpi_time vpi_time = {};
     vpi_time.high = (uint32_t)(time >> 32);
     vpi_time.low = (uint32_t)(time);
     vpi_time.type = vpiSimTime;
 
-    cb_data.reason = cbAfterDelay;
+    s_cb_data vpi_cb_data = {};
+    vpi_cb_data.reason = reason_from_cb_kind(kind);
+    vpi_cb_data.cb_rtn = handle_vpi_callback;
+    vpi_cb_data.time = &vpi_time;
+    vpi_cb_data.user_data = (char *)cb;
+
+    vpiHandle sim_cb_hdl = vpi_register_cb(&vpi_cb_data);
+
+    bool valid_cb = true;
+    // LCOV_EXCL_START
+    if (!sim_cb_hdl) {
+        check_vpi_error();
+        LOG_ERROR(
+            "VPI: Unable to register a callback handle for VPI type %s(%d)",
+            reason_to_string(vpi_cb_data.reason), vpi_cb_data.reason);
+        valid_cb = false;
+    }
+    // LCOV_EXCL_STOP
+
+    if (valid_cb) {
+        cb->impl = this;
+        cb->sim_cb_hdl = sim_cb_hdl;
+        cb->user_cb_func = cb_func;
+        cb->user_cb_data = cb_data;
+        cb->kind = CB_TIMED;
+
+        ret_hdl.index = cb->index;
+        ret_hdl.meta = cb->meta;
+    }
+    // LCOV_EXCL_START
+    else {
+        gpi_callback_release(cb);
+    }
+    // LCOV_EXCL_STOP
+
+    return ret_hdl;
+}
+gpi_hdl VpiImpl::register_timed_callback(uint64_t time, int (*cb_func)(void *),
+                                         void *cb_data) {
+    return register_non_valuechange_callback(CB_TIMED, time, cb_func, cb_data);
 }
 
-VpiReadWriteCbHdl::VpiReadWriteCbHdl(GpiImplInterface *impl) : VpiCbHdl(impl) {
-    cb_data.reason = cbReadWriteSynch;
+gpi_hdl VpiImpl::register_readonly_callback(int (*cb_func)(void *),
+                                            void *cb_data) {
+    return register_non_valuechange_callback(CB_READONLY, 0, cb_func, cb_data);
 }
 
-VpiReadOnlyCbHdl::VpiReadOnlyCbHdl(GpiImplInterface *impl) : VpiCbHdl(impl) {
-    cb_data.reason = cbReadOnlySynch;
+gpi_hdl VpiImpl::register_readwrite_callback(int (*cb_func)(void *),
+                                             void *cb_data) {
+    return register_non_valuechange_callback(CB_READWRITE, 0, cb_func, cb_data);
 }
 
-VpiNextPhaseCbHdl::VpiNextPhaseCbHdl(GpiImplInterface *impl) : VpiCbHdl(impl) {
-    cb_data.reason = cbNextSimTime;
+gpi_hdl VpiImpl::register_nexttime_callback(int (*cb_func)(void *),
+                                            void *cb_data) {
+    return register_non_valuechange_callback(CB_NEXT_TIMESTEP, 0, cb_func,
+                                             cb_data);
+}
+
+int VpiImpl::remove_callback(gpi_callback *cb) {
+    if (cb->removed) {
+        return 0;
+    }
+
+    // Mark as removed
+    cb->removed = true;
+
+    switch (cb->kind & CB_BASIC_KIND) {
+        case CB_READWRITE:
+        case CB_READONLY:
+        case CB_NEXT_TIMESTEP:
+        case CB_TIMED: {
+            vpiHandle sim_cb_hdl = static_cast<vpiHandle>(cb->sim_cb_hdl);
+            int remove_success = vpi_remove_cb(sim_cb_hdl);
+
+            // LCOV_EXCL_START
+            if (!remove_success) {
+                LOG_DEBUG("VPI: Unable to remove %s callback index %d!",
+                          cb_kind_to_string(cb->kind), cb->index);
+                check_vpi_error();
+
+                // It is already marked removed but we don't release it until
+                // the callback fires
+            }
+            // LCOV_EXCL_STOP
+            else {
+                gpi_callback_release(cb);
+            }
+            break;
+        }
+        case CB_STARTUP:
+        case CB_SHUTDOWN: {
+            // Too many sims get upset trying to remove startup callbacks so we
+            // just don't try.
+            break;
+        }
+        case CB_VALUE_CHANGE: {
+            // There are two types of value change callbacks to remove.
+            // 1. User callbacks that are children of a parent callback
+            // 2. Parent callbacks that are associated with the simulator
+            // callback
+            //
+            // For user callbacks, we mark them for cleanup later,
+            // before the sim callback returns.
+            // In the later cleanup, if all child callbacks have been removed
+            // and marked for cleanup,
+            // this function will get called on the parent callback.
+            // In that case, we try to remove the sim callback
+            // and clear it from the associated signal object.
+
+            if (cb->kind & CB_PARENT) {
+#ifndef VPI_NO_QUEUE_SETIMMEDIATE_CALLBACKS
+                // check if it's already fired and is in callback queue
+                auto it = std::find(cb_queue.begin(), cb_queue.end(), cb);
+                if (it != cb_queue.end()) {
+                    cb_queue.erase(it);
+                }
+#endif
+
+                vpiHandle sim_cb_hdl = static_cast<vpiHandle>(cb->sim_cb_hdl);
+                int remove_success = vpi_remove_cb(sim_cb_hdl);
+
+                // LCOV_EXCL_START
+                if (!remove_success) {
+                    LOG_DEBUG(
+                        "VPI: Unable to remove valuechange callback index %d!",
+                        cb->index);
+                    check_vpi_error();
+
+                    // It is already marked removed but we don't release it
+                    // until the callback fires
+                }
+                // LCOV_EXCL_STOP
+                else {
+                    gpi_callback_release(cb);
+
+                    cb->signal->m_valuechange_cb = nullptr;
+                }
+            } else {
+                // Don't release it here, just mark it to be cleaned up before
+                // the callback returns
+                gpi_mark_valuechange_for_cleanup(cb);
+            }
+            break;
+        }
+
+        default:
+            break;
+    }
+
+    return 0;
+}
+
+gpi_hdl VpiSignalObjHdl::register_value_change_callback(gpi_edge edge,
+                                                        int (*cb_func)(void *),
+                                                        void *cb_data) {
+    gpi_hdl ret_hdl = gpi_nil_hdl;
+
+    gpi_callback *user_cb = gpi_callback_acquire();
+
+    bool valid_cb = true;
+    if (m_valuechange_cb) {
+        // If there is already a sim callback,
+        // add a user callback to the end of the list.
+        user_cb->impl = m_impl;
+        user_cb->parent = m_valuechange_cb;
+        user_cb->user_cb_func = cb_func;
+        user_cb->user_cb_data = cb_data;
+        user_cb->edge = edge;
+        user_cb->kind = CB_VALUE_CHANGE;
+
+        // Update parent
+        m_valuechange_cb->last->next = user_cb;
+        user_cb->prev = m_valuechange_cb->last;
+        m_valuechange_cb->last = user_cb;
+
+        LOG_TRACE(
+            "VPI: new valuechange child callback index %d added to existing "
+            "parent callback index %d",
+            user_cb->index, m_valuechange_cb->index);
+    } else {
+        // If there is no sim callback,
+        // register one with a parent callback object and start the user
+        // callback list.
+
+        gpi_callback *parent_cb = gpi_callback_acquire();
+
+        s_vpi_time vpi_time = {};
+        vpi_time.type = vpiSuppressTime;
+        s_vpi_value vpi_value = {};
+
+        // The value is not needed in the callback data.
+        // Any getting of values will be done separately.
+        vpi_value.format = vpiSuppressVal;
+
+        s_cb_data vpi_cb_data = {};
+        vpi_cb_data.reason = reason_from_cb_kind(CB_VALUE_CHANGE);
+        vpi_cb_data.cb_rtn = handle_vpi_callback;
+        vpi_cb_data.obj = get_handle<vpiHandle>();
+        vpi_cb_data.value = &vpi_value;
+        vpi_cb_data.time = &vpi_time;
+        vpi_cb_data.user_data = (char *)parent_cb;
+
+        vpiHandle sim_cb_hdl = vpi_register_cb(&vpi_cb_data);
+
+        bool valid_sim_cb = true;
+        // LCOV_EXCL_START
+        if (!sim_cb_hdl) {
+            check_vpi_error();
+            LOG_ERROR(
+                "VPI: Unable to register a callback handle for VPI type "
+                "%s(%d)",
+                VpiImpl::reason_to_string(vpi_cb_data.reason),
+                vpi_cb_data.reason);
+            valid_sim_cb = false;
+        }
+        // LCOV_EXCL_STOP
+
+        if (valid_sim_cb) {
+            parent_cb->impl = m_impl;
+            parent_cb->sim_cb_hdl = sim_cb_hdl;
+            parent_cb->next = user_cb;
+            parent_cb->last = user_cb;
+            parent_cb->signal = this;
+            parent_cb->kind = CB_VALUE_CHANGE | CB_PARENT;
+
+            user_cb->impl = m_impl;
+            user_cb->parent = parent_cb;
+            user_cb->prev = parent_cb;
+            user_cb->user_cb_func = cb_func;
+            user_cb->user_cb_data = cb_data;
+            user_cb->edge = edge;
+            user_cb->kind = CB_VALUE_CHANGE;
+
+            m_valuechange_cb = parent_cb;
+
+            LOG_TRACE(
+                "VPI: from sim callback %p -> new valuechange parent callback "
+                "index %d and child callback index %d",
+                sim_cb_hdl, parent_cb->index, user_cb->index);
+        }
+        // LCOV_EXCL_START
+        else {
+            gpi_callback_release(parent_cb);
+            valid_cb = false;
+        }
+        // LCOV_EXCL_STOP
+    }
+
+    if (valid_cb) {
+        ret_hdl.index = user_cb->index;
+        ret_hdl.meta = user_cb->meta;
+    }
+    // LCOV_EXCL_START
+    else {
+        gpi_callback_release(user_cb);
+    }
+    // LCOV_EXCL_STOP
+
+    return ret_hdl;
 }

--- a/src/cocotb/share/lib/gpi/vpi/VpiImpl.cpp
+++ b/src/cocotb/share/lib/gpi/vpi/VpiImpl.cpp
@@ -681,67 +681,10 @@ GpiIterator *VpiImpl::iterate_handle(GpiObjHdl *obj_hdl,
     return new_iter;
 }
 
-GpiCbHdl *VpiImpl::register_timed_callback(uint64_t time,
-                                           int (*cb_func)(void *),
-                                           void *cb_data) {
-    auto cb_hdl = new VpiTimedCbHdl(this, time);
-    auto err = cb_hdl->arm();
-    // LCOV_EXCL_START
-    if (err) {
-        delete cb_hdl;
-        return NULL;
-    }
-    // LCOV_EXCL_STOP
-    cb_hdl->set_cb_info(cb_func, cb_data);
-    return cb_hdl;
-}
-
-GpiCbHdl *VpiImpl::register_readwrite_callback(int (*cb_func)(void *),
-                                               void *cb_data) {
-    auto cb_hdl = new VpiReadWriteCbHdl(this);
-    auto err = cb_hdl->arm();
-    // LCOV_EXCL_START
-    if (err) {
-        delete cb_hdl;
-        return NULL;
-    }
-    // LCOV_EXCL_STOP
-    cb_hdl->set_cb_info(cb_func, cb_data);
-    return cb_hdl;
-}
-
-GpiCbHdl *VpiImpl::register_readonly_callback(int (*cb_func)(void *),
-                                              void *cb_data) {
-    auto cb_hdl = new VpiReadOnlyCbHdl(this);
-    auto err = cb_hdl->arm();
-    // LCOV_EXCL_START
-    if (err) {
-        delete cb_hdl;
-        return NULL;
-    }
-    // LCOV_EXCL_STOP
-    cb_hdl->set_cb_info(cb_func, cb_data);
-    return cb_hdl;
-}
-
-GpiCbHdl *VpiImpl::register_nexttime_callback(int (*cb_func)(void *),
-                                              void *cb_data) {
-    auto cb_hdl = new VpiNextPhaseCbHdl(this);
-    auto err = cb_hdl->arm();
-    // LCOV_EXCL_START
-    if (err) {
-        delete cb_hdl;
-        return NULL;
-    }
-    // LCOV_EXCL_STOP
-    cb_hdl->set_cb_info(cb_func, cb_data);
-    return cb_hdl;
-}
-
 // If the Python world wants things to shut down then unregister
 // the callback for end of sim
 void VpiImpl::sim_end() {
-    m_sim_finish_cb->remove();
+    remove_callback(m_sim_finish_cb);
 #ifdef ICARUS
     // Must skip checking return value on Icarus because their version of
     // vpi_control() returns void for some reason.
@@ -784,33 +727,34 @@ static int shutdown_callback(void *) {
 }
 
 void VpiImpl::main() noexcept {
-    auto startup_cb = new VpiStartupCbHdl(this);
-    auto err = startup_cb->arm();
+    gpi_hdl startup_hdl = register_non_valuechange_callback(
+        CB_STARTUP, 0, startup_callback, nullptr);
+
     // LCOV_EXCL_START
-    if (err) {
+    if (!(startup_hdl.meta & META_VALID)) {
         LOG_CRITICAL(
             "VPI: Unable to register startup callback! Simulation will end.");
         check_vpi_error();
-        delete startup_cb;
         exit(1);
     }
     // LCOV_EXCL_STOP
-    startup_cb->set_cb_info(startup_callback, nullptr);
 
-    auto shutdown_cb = new VpiShutdownCbHdl(this);
-    err = shutdown_cb->arm();
+    gpi_callback *startup_cb = gpi_callback_from_index(startup_hdl.index);
+
+    gpi_hdl shutdown_hdl = register_non_valuechange_callback(
+        CB_SHUTDOWN, 0, shutdown_callback, nullptr);
+
     // LCOV_EXCL_START
-    if (err) {
+    if (!(shutdown_hdl.meta & META_VALID)) {
         LOG_CRITICAL(
             "VPI: Unable to register shutdown callback! Simulation will end.");
         check_vpi_error();
-        startup_cb->remove();
-        delete shutdown_cb;
+        remove_callback(startup_cb);
         exit(1);
     }
     // LCOV_EXCL_STOP
-    shutdown_cb->set_cb_info(shutdown_callback, nullptr);
-    m_sim_finish_cb = shutdown_cb;
+
+    m_sim_finish_cb = gpi_callback_from_index(shutdown_hdl.index);
 
     gpi_register_impl(this);
     gpi_entry_point();

--- a/src/cocotb/share/lib/gpi/vpi/VpiImpl.hpp
+++ b/src/cocotb/share/lib/gpi/vpi/VpiImpl.hpp
@@ -71,100 +71,7 @@ static inline void __check_vpi_error(const char *file, const char *func,
         __check_vpi_error(__FILE__, __func__, __LINE__); \
     } while (0)
 
-class VpiCbHdl : public GpiCbHdl {
-  public:
-    VpiCbHdl(GpiImplInterface *impl);
-
-    int arm() override;
-    int remove() override;
-    int run() override;
-
-  protected:
-    s_cb_data cb_data;
-    s_vpi_time vpi_time;
-    bool m_removed = false;
-};
-
 class VpiSignalObjHdl;
-
-class VpiValueCbHdl : public VpiCbHdl {
-  public:
-    VpiValueCbHdl(GpiImplInterface *impl, VpiSignalObjHdl *sig, gpi_edge edge);
-    int run() override;
-
-  private:
-    s_vpi_value m_vpi_value;
-    GpiSignalObjHdl *m_signal;
-    gpi_edge m_edge;
-};
-
-class VpiTimedCbHdl : public VpiCbHdl {
-  public:
-    VpiTimedCbHdl(GpiImplInterface *impl, uint64_t time);
-};
-
-class VpiReadOnlyCbHdl : public VpiCbHdl {
-  public:
-    VpiReadOnlyCbHdl(GpiImplInterface *impl);
-};
-
-class VpiNextPhaseCbHdl : public VpiCbHdl {
-  public:
-    VpiNextPhaseCbHdl(GpiImplInterface *impl);
-};
-
-class VpiReadWriteCbHdl : public VpiCbHdl {
-  public:
-    VpiReadWriteCbHdl(GpiImplInterface *impl);
-};
-
-class VpiStartupCbHdl : public VpiCbHdl {
-  public:
-    VpiStartupCbHdl(GpiImplInterface *impl);
-
-    // Too many sims get upset trying to remove startup callbacks so we just
-    // don't try. TODO Is this still accurate?
-
-    int run() override {
-        int res = 0;
-        if (!m_removed) {
-            res = m_cb_func(m_cb_data);
-        } else {
-            LOG_TRACE("[ VPI (startup) ] callback is removed");
-        }
-        delete this;
-        return res;
-    }
-
-    int remove() override {
-        m_removed = true;
-        return 0;
-    }
-};
-
-class VpiShutdownCbHdl : public VpiCbHdl {
-  public:
-    VpiShutdownCbHdl(GpiImplInterface *impl);
-
-    // Too many sims get upset trying to remove startup callbacks so we just
-    // don't try. TODO Is this still accurate?
-
-    int run() override {
-        int res = 0;
-        if (!m_removed) {
-            res = m_cb_func(m_cb_data);
-        } else {
-            LOG_TRACE("[ VPI (shutdown) ] callback is removed");
-        }
-        delete this;
-        return res;
-    }
-
-    int remove() override {
-        m_removed = true;
-        return 0;
-    }
-};
 
 class VpiArrayObjHdl : public GpiObjHdl {
   public:
@@ -202,12 +109,11 @@ class VpiSignalObjHdl : public GpiSignalObjHdl {
     int set_signal_value_str(std::string &value,
                              gpi_set_action action) override;
 
-    /* Value change callback accessor */
     int initialise(const std::string &name,
                    const std::string &fq_name) override;
-    GpiCbHdl *register_value_change_callback(gpi_edge edge,
-                                             int (*function)(void *),
-                                             void *cb_data) override;
+    gpi_hdl register_value_change_callback(gpi_edge edge,
+                                           int (*function)(void *),
+                                           void *cb_data) override;
     int get_signed() override;
 
   private:
@@ -297,15 +203,23 @@ class VpiImpl : public GpiImplInterface {
                                 gpi_iterator_sel type) override;
     GpiObjHdl *next_handle(GpiIterator *iter);
 
-    /* Callback related, these may (will) return the same handle*/
-    GpiCbHdl *register_timed_callback(uint64_t time, int (*function)(void *),
-                                      void *cb_data) override;
-    GpiCbHdl *register_readonly_callback(int (*function)(void *),
-                                         void *cb_data) override;
-    GpiCbHdl *register_nexttime_callback(int (*function)(void *),
-                                         void *cb_data) override;
-    GpiCbHdl *register_readwrite_callback(int (*function)(void *),
-                                          void *cb_data) override;
+    /* Callback related */
+
+    // Helper function to hold common functionality
+    gpi_hdl register_non_valuechange_callback(cb_kind kind, uint64_t time,
+                                              int (*cb_func)(void *),
+                                              void *cb_data);
+
+    gpi_hdl register_timed_callback(uint64_t time, int (*function)(void *),
+                                    void *cb_data) override;
+    gpi_hdl register_readonly_callback(int (*function)(void *),
+                                       void *cb_data) override;
+    gpi_hdl register_nexttime_callback(int (*function)(void *),
+                                       void *cb_data) override;
+    gpi_hdl register_readwrite_callback(int (*function)(void *),
+                                        void *cb_data) override;
+    int remove_callback(gpi_callback *cb) override;
+
     GpiObjHdl *get_child_by_name(const std::string &name,
                                  GpiObjHdl *parent) override;
     GpiObjHdl *get_child_by_index(int32_t index, GpiObjHdl *parent) override;
@@ -323,9 +237,10 @@ class VpiImpl : public GpiImplInterface {
     void main() noexcept;
 
   private:
-    // We store the shutdown callback handle here so sim_end() can remove() it
-    // if it's called.
-    VpiShutdownCbHdl *m_sim_finish_cb;
+    // We store the shutdown callback handle here so that if sim_end() is
+    // called, it can be removed.
+    gpi_callback *m_sim_finish_cb;
+
     std::string m_product;
     std::string m_version;
     int m_argc = 0;

--- a/src/cocotb/share/lib/gpi/vpi/VpiSignal.cpp
+++ b/src/cocotb/share/lib/gpi/vpi/VpiSignal.cpp
@@ -231,14 +231,3 @@ int VpiSignalObjHdl::set_signal_value(s_vpi_value value_s,
 
     return 0;
 }
-
-GpiCbHdl *VpiSignalObjHdl::register_value_change_callback(
-    gpi_edge edge, int (*cb_func)(void *), void *cb_data) {
-    VpiValueCbHdl *cb_hdl = new VpiValueCbHdl(this->m_impl, this, edge);
-    if (cb_hdl->arm()) {
-        delete this;
-        return NULL;
-    }
-    cb_hdl->set_cb_info(cb_func, cb_data);
-    return cb_hdl;
-}

--- a/src/cocotb/share/lib/pygpi/bind.cpp
+++ b/src/cocotb/share/lib/pygpi/bind.cpp
@@ -24,6 +24,9 @@
 
 #define MODULE_NAME "simulator"
 
+// Typed nullptr for object creation
+gpi_cb_hdl null_cb_hdl = nullptr;
+
 // callback user data
 struct PythonCallback {
     PythonCallback(PyObject *func, PyObject *_args, PyObject *_kwargs)
@@ -51,6 +54,7 @@ namespace {
 template <typename gpi_hdl_type>
 struct gpi_hdl_Object {
     PyObject_HEAD gpi_hdl_type hdl;
+    gpi_hdl new_hdl;
 
     // The python type object, in a place that is easy to retrieve in templates
     static PyTypeObject py_type;
@@ -79,8 +83,8 @@ static Py_hash_t gpi_hdl_hash(gpi_hdl_Object<gpi_hdl_type> *self) {
  * pointer is NULL.
  */
 template <typename gpi_hdl_type>
-static PyObject *gpi_hdl_New(gpi_hdl_type hdl) {
-    if (hdl == NULL) {
+static PyObject *gpi_hdl_New(gpi_hdl_type hdl, gpi_hdl new_hdl) {
+    if (hdl == NULL && gpi_hdl_is_nil(new_hdl)) {
         Py_RETURN_NONE;
     }
     auto *obj = PyObject_New(gpi_hdl_Object<gpi_hdl_type>,
@@ -89,6 +93,7 @@ static PyObject *gpi_hdl_New(gpi_hdl_type hdl) {
         return NULL;
     }
     obj->hdl = hdl;
+    obj->new_hdl = new_hdl;
     return (PyObject *)obj;
 }
 
@@ -231,10 +236,10 @@ static PyObject *register_readonly_callback(PyObject *, PyObject *args) {
 
     PythonCallback *cb_data = new PythonCallback(function, fArgs, NULL);
 
-    gpi_cb_hdl hdl = gpi_register_readonly_callback(
+    gpi_hdl hdl = gpi_register_readonly_callback(
         (gpi_function_t)handle_gpi_callback, cb_data);
 
-    PyObject *rv = gpi_hdl_New(hdl);
+    PyObject *rv = gpi_hdl_New(null_cb_hdl, hdl);
 
     return rv;
 }
@@ -272,10 +277,10 @@ static PyObject *register_rwsynch_callback(PyObject *, PyObject *args) {
 
     PythonCallback *cb_data = new PythonCallback(function, fArgs, NULL);
 
-    gpi_cb_hdl hdl = gpi_register_readwrite_callback(
+    gpi_hdl hdl = gpi_register_readwrite_callback(
         (gpi_function_t)handle_gpi_callback, cb_data);
 
-    PyObject *rv = gpi_hdl_New(hdl);
+    PyObject *rv = gpi_hdl_New(null_cb_hdl, hdl);
 
     return rv;
 }
@@ -313,10 +318,10 @@ static PyObject *register_nextstep_callback(PyObject *, PyObject *args) {
 
     PythonCallback *cb_data = new PythonCallback(function, fArgs, NULL);
 
-    gpi_cb_hdl hdl = gpi_register_nexttime_callback(
+    gpi_hdl hdl = gpi_register_nexttime_callback(
         (gpi_function_t)handle_gpi_callback, cb_data);
 
-    PyObject *rv = gpi_hdl_New(hdl);
+    PyObject *rv = gpi_hdl_New(null_cb_hdl, hdl);
 
     return rv;
 }
@@ -373,11 +378,11 @@ static PyObject *register_timed_callback(PyObject *, PyObject *args) {
 
     PythonCallback *cb_data = new PythonCallback(function, fArgs, NULL);
 
-    gpi_cb_hdl hdl = gpi_register_timed_callback(
+    gpi_hdl hdl = gpi_register_timed_callback(
         (gpi_function_t)handle_gpi_callback, cb_data, time);
 
     // Check success
-    PyObject *rv = gpi_hdl_New(hdl);
+    PyObject *rv = gpi_hdl_New(null_cb_hdl, hdl);
 
     return rv;
 }
@@ -431,11 +436,11 @@ static PyObject *register_value_change_callback(
 
     PythonCallback *cb_data = new PythonCallback(function, fArgs, NULL);
 
-    gpi_cb_hdl hdl = gpi_register_value_change_callback(
+    gpi_hdl hdl = gpi_register_value_change_callback(
         (gpi_function_t)handle_gpi_callback, cb_data, sig_hdl, edge);
 
     // Check success
-    PyObject *rv = gpi_hdl_New(hdl);
+    PyObject *rv = gpi_hdl_New(null_cb_hdl, hdl);
 
     return rv;
 }
@@ -449,13 +454,13 @@ static PyObject *iterate(gpi_hdl_Object<gpi_sim_hdl> *self, PyObject *args) {
 
     gpi_iterator_hdl result = gpi_iterate(self->hdl, (gpi_iterator_sel)type);
 
-    return gpi_hdl_New(result);
+    return gpi_hdl_New(result, gpi_nil_hdl);
 }
 
 static PyObject *package_iterate(PyObject *, PyObject *) {
     gpi_iterator_hdl result = gpi_iterate(NULL, GPI_PACKAGE_SCOPES);
 
-    return gpi_hdl_New(result);
+    return gpi_hdl_New(result, gpi_nil_hdl);
 }
 
 static PyObject *iterator_next(gpi_hdl_Object<gpi_iterator_hdl> *self) {
@@ -467,7 +472,7 @@ static PyObject *iterator_next(gpi_hdl_Object<gpi_iterator_hdl> *self) {
         return NULL;
     }
 
-    return gpi_hdl_New(result);
+    return gpi_hdl_New(result, gpi_nil_hdl);
 }
 
 // Raise an exception on failure
@@ -598,7 +603,7 @@ static PyObject *get_handle_by_name(gpi_hdl_Object<gpi_sim_hdl> *self,
     gpi_sim_hdl result =
         gpi_get_handle_by_name(self->hdl, name, c_discovery_method);
 
-    return gpi_hdl_New(result);
+    return gpi_hdl_New(result, gpi_nil_hdl);
 }
 
 static PyObject *get_handle_by_index(gpi_hdl_Object<gpi_sim_hdl> *self,
@@ -611,7 +616,7 @@ static PyObject *get_handle_by_index(gpi_hdl_Object<gpi_sim_hdl> *self,
 
     gpi_sim_hdl result = gpi_get_handle_by_index(self->hdl, index);
 
-    return gpi_hdl_New(result);
+    return gpi_hdl_New(result, gpi_nil_hdl);
 }
 
 static PyObject *get_root_handle(PyObject *, PyObject *args) {
@@ -631,7 +636,7 @@ static PyObject *get_root_handle(PyObject *, PyObject *args) {
         Py_RETURN_NONE;
     }
 
-    return gpi_hdl_New(result);
+    return gpi_hdl_New(result, gpi_nil_hdl);
 }
 
 static PyObject *get_name_string(gpi_hdl_Object<gpi_sim_hdl> *self,
@@ -792,12 +797,16 @@ static PyObject *stop_simulator(PyObject *, PyObject *) {
 static PyObject *deregister(gpi_hdl_Object<gpi_cb_hdl> *self, PyObject *) {
     // cleanup uncalled callback
     void *cb_data;
-    gpi_get_cb_info(self->hdl, nullptr, &cb_data);
-    auto cb = static_cast<PythonCallback *>(cb_data);
-    delete cb;
+    int error = gpi_get_cb_info(self->new_hdl, nullptr, &cb_data);
+    if (!error) {
+        auto cb = static_cast<PythonCallback *>(cb_data);
+        delete cb;
+    }
 
     // deregister from interface
-    gpi_remove_cb(self->hdl);
+    gpi_remove_cb(self->new_hdl);
+
+    (void)self;
 
     Py_RETURN_NONE;
 }
@@ -859,7 +868,7 @@ class GpiClock {
 
   private:
     GpiObjHdl *clk_signal = nullptr;
-    GpiCbHdl *clk_toggle_cb_hdl = nullptr;
+    gpi_hdl clk_toggle_cb_hdl = gpi_nil_hdl;
 
     uint64_t period = 0;
     uint64_t t_high = 0;
@@ -873,7 +882,7 @@ class GpiClock {
 
 int GpiClock::start(uint64_t period_steps, uint64_t high_steps, bool start_high,
                     gpi_set_action set_action) {
-    if (clk_toggle_cb_hdl) {
+    if (!gpi_hdl_is_nil(clk_toggle_cb_hdl)) {
         return EBUSY;
     }
     if ((period_steps < 2) || (high_steps < 1) ||
@@ -890,11 +899,11 @@ int GpiClock::start(uint64_t period_steps, uint64_t high_steps, bool start_high,
 }
 
 int GpiClock::stop() {
-    if (!clk_toggle_cb_hdl) {
+    if (gpi_hdl_is_nil(clk_toggle_cb_hdl)) {
         return -1;
     }
     gpi_remove_cb(clk_toggle_cb_hdl);
-    clk_toggle_cb_hdl = nullptr;
+    clk_toggle_cb_hdl = gpi_nil_hdl;
     return 0;
 }
 
@@ -908,7 +917,7 @@ int GpiClock::toggle(bool initialSet) {
 
     clk_toggle_cb_hdl =
         gpi_register_timed_callback(&GpiClock::toggle_cb, this, to_next_edge);
-    if (!clk_toggle_cb_hdl) {
+    if (gpi_hdl_is_nil(clk_toggle_cb_hdl)) {
         // LCOV_EXCL_START
         if (!initialSet) {
             // Failing when called from start() will be reported via
@@ -952,7 +961,7 @@ static PyObject *clock_create(PyObject *, PyObject *args) {
     GpiClock *gpi_clk = new GpiClock(sim_hdl);
 
     if (gpi_clk) {
-        return gpi_hdl_New(gpi_clk);
+        return gpi_hdl_New(gpi_clk, gpi_nil_hdl);
     } else {
         // LCOV_EXCL_START
         PyErr_SetString(PyExc_RuntimeError, "Failed to create clock!");

--- a/tests/test_cases/test_first_on_coincident_triggers/test_first_on_coincident_triggers.py
+++ b/tests/test_cases/test_first_on_coincident_triggers/test_first_on_coincident_triggers.py
@@ -37,14 +37,6 @@ async def test_first_on_coincident_trigger(dut) -> None:
 
 
 @cocotb.xfail(
-    SIM_NAME.startswith("nvc"),
-    reason="NVC doesn't fire second RisingEdge trigger for dut.b when it is registered the same time step that a change occurred (gh-5112)",
-)
-@cocotb.xfail(
-    SIM_NAME.startswith("verilator"),
-    reason="Verilator doesn't fire second RisingEdge trigger for dut.b when it is registered the same time step that a change occurred (gh-5112)",
-)
-@cocotb.xfail(
     SIM_NAME.startswith("riviera"),
     reason="Riviera doesn't fire second RisingEdge trigger for dut.b when it is registered the same time step that a change occurred (gh-5112)",
 )
@@ -59,10 +51,6 @@ async def test_first_on_coincident_trigger(dut) -> None:
 @cocotb.skipif(
     SIM_NAME.startswith("modelsim") and LANGUAGE in ["vhdl"] and VHDL_INTF in ["fli"],
     reason="Questa will segfault",
-)
-@cocotb.xfail(
-    SIM_NAME.startswith("ghdl"),
-    reason="GHDL doesn't fire second RisingEdge trigger for dut.b when it is registered the same time step that a change occurred (gh-5112)",
 )
 # Setting timeout because even though GHDL fails the test correctly, it gets stuck and doesn't finish simulation (gh-4997)
 @cocotb.test(timeout_time=100, timeout_unit="ns")


### PR DESCRIPTION
This is a large refactor of GPI callbacks.

From a GPI user perspective, the main change is from `gpi_cb_hdl` handle type, which is an opaque pointer, to the new `gpi_hdl` handle type, which is a simple POD struct.

Using a handle disconnects the internal implementation of an object and its address from the external identifier.
The handle includes an index and handle generation data, so we can detect out of date handles and not have use-after-free problems.

Internally, we replace the large C++ class hierarchy with a single `gpi_callback` "fat struct":

<img width="1172" height="888" alt="callback-hierarchy-refactor" src="https://github.com/user-attachments/assets/4b157d6f-3af0-4941-b1b4-e6d769310425" />

The callback object pool is implemented with the Xar (Exponential Array) approach, where we build the array by allocating large sub-array chunks, taking advantage of some specific chunk sizing to get fast index -> chunk + offset lookup.
See Andrew Reece's talk at the 2025 Better Software Conference for details (timestamped video: https://youtu.be/i-h95QIGchY?t=3192).

A growing arena/bump allocator would be preferred, but I didn't want to introduce platform-specific virtual memory management at this point, and I didn't want to deal with a fixed callback pool size (either fixed at compile time or allocated with a configurable environment variable). So instead the first chunk is 4096 (larger than most users should ever need) but we can support an absurd number of concurrent callbacks in the edge case with only a few pointers worth of overhead in the usual case.

The other change is that we now support multiple `ValueChange` user callbacks for a single simulator callback.
The parent callback associated with the simulator callback maintains a list of child user callbacks.

---
## GPI Implementation details

### User handles

`index` is the index in the object pool.
`meta` matches the field on the `gpi_callback` object. We care about the generation matching, but for simplicity we just copy the field when returning a `gpi_hdl`.

<img width="311" height="331" alt="gpi-callback-refactor-user-handles" src="https://github.com/user-attachments/assets/b1837ac9-f292-412c-8ba3-e9280a80c8fa" />

### Non-ValueChange callbacks

These callbacks track the sim callback object and the user function+data directly.

<img width="378" height="486" alt="gpi-callback-refactor-single-callbacks" src="https://github.com/user-attachments/assets/30c52290-dca6-4f1e-9242-c4ce22d2b904" />

### ValueChange callback list

This shows the linked-list of callbacks. The first is the parent callback, and the rest are user callbacks.

<img width="907" height="554" alt="gpi-callback-refactor-valuechange-list" src="https://github.com/user-attachments/assets/d862af21-1cad-4a76-add1-6c8870432976" />

### ValueChange callback with signal

The signal and parent callback have pointers to each other. The parent callback also tracks the last user callback so that we don't get stuck in an infinite loop if the user callback registers another `ValueChange` callback on the same signal.

<img width="806" height="1120" alt="gpi-callback-refactor-valuechange-signal" src="https://github.com/user-attachments/assets/148b13b9-2d0d-4110-8bba-c0b6be90e0ae" />

